### PR TITLE
Minor documentation corrections:

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ plugin:
         }
 
         dependencies {
-            classpath 'com.netflix.nebula:gradle-rpm-plugin:1.8.4'
+            classpath 'com.netflix.nebula:gradle-ospackage-plugin:1.9.1'
         }
     }
 ```
@@ -51,7 +51,7 @@ ospackage {
     release '3'
     os = LINUX // only applied to RPM
     into '/opt/app1'
-    from file('dist') {
+    from ('dist') {
         user 'builds'
         exclude '**/*.rb'
     }
@@ -80,7 +80,7 @@ ospackage {
     release '3'
     os = LINUX // only applied to RPM
     into '/opt/app1'
-    from file('dist') {
+    from ('dist') {
         user 'builds'
         exclude '**/*.rb'
     }
@@ -97,11 +97,11 @@ buildRpm {
 ```
     buildscript {
         repositories {
-            mavenCentral()
+            jcenter()
         }
 
         dependencies {
-            classpath 'com.trigonic:gradle-rpm-plugin:2.0'
+            classpath 'com.netflix.nebula:gradle-ospackage-plugin:1.9.1'
         }
     }
 


### PR DESCRIPTION
1: Corrected plugin artefact co-ordinates
2: Corrected example usages of 'from'

Thought I'd submit these minor doc tweaks in case they're of interest.

I was reading the gradle-rpm-plugin issue list last night and noticed this plugin had recently been created (great work by the way!). I noticed that this plugin works well with Gradle 1.10 whereas I know the original RPM plugin has a few issues using internal Gradle APIs which have changed between releases (CopySpec etc). So I was wondering if there's an intention to replace the gradle-rpm-plugin with this one? 
