### PR TITLE
Fix paths for `link(..)` in examples.

### DIFF
--- a/Plugin-Deb.md
+++ b/Plugin-Deb.md
@@ -56,8 +56,10 @@ be set, which are specific to DEBs. Quite of them have defaults which fall back 
 Symbolic links are specified via the links method, where the permissions umask is optional:
 
 ```
-link(String src, String dest, int permissions)
+link(String symLinkPath, String targetPath, int permissions)
 ```
+
+
 
 # Requires
 
@@ -137,7 +139,7 @@ The following attributes can be used inside _from_ and _into_ closures to comple
             into '/usr/share/tomcat/endorsed'
         }
 
-        link('/opt/foo/bin/foo.init', '/etc/init.d/foo')
+        link('/etc/init.d/foo', '/opt/foo/bin/foo.init')
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ buildRpm {
 
     buildDeb {
         requires('bat', '1.0.1')
-        link('/opt/foo/bin/foo.upstart', '/etc/init.d/foo')
+        link('/etc/init.d/foo', '/opt/foo/bin/foo.upstart')
     }
 
 ```


### PR DESCRIPTION
After attempting to follow the examples in my own deb files, I found that the examples' paths were reversed, leading to errors like this:

```
sudo dpkg -i collector_1.0_all.deb
Selecting previously unselected package collector.
(Reading database ... 101946 files and directories currently installed.)
Unpacking collector (fromcollector_1.0_all.deb) ...
dpkg: error processing collector_1.0_all.deb (--install):
 unable to open '/opt/avram/collector/scripts/collector.conf.dpkg-new': No such file or directory
Errors were encountered while processing:
  collector_1.0_all.deb
```

I assume that this applies to the RPM docs as well, but I haven't been making RPMs and would like to confirm they are also affecting before fixing the docs there.
