### PR TITLE
fix "=" version comparison for debian

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -159,7 +159,7 @@ class DebCopyAction extends AbstractPackagingCopyAction {
     def signMap = [
             (Flags.GREATER|Flags.EQUAL): '>=',
             (Flags.LESS|Flags.EQUAL):    '<=',
-            (Flags.EQUAL):               '==',
+            (Flags.EQUAL):               '=',
             (Flags.GREATER):             '>>',
             (Flags.LESS):                '<<'
     ]


### PR DESCRIPTION
The equals operator for Debian Depends is "=" not "==".
