### PR TITLE
Fixed rpm task on hosts with incorrect hostname

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -33,7 +33,7 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
 
     ProjectPackagingExtension parentExten
 
-    static InetAddress machineAddress = InetAddress.localHost
+    static InetAddress machineAddress = getLocalHost()
 
     // TODO Add conventions to pull from extension
 
@@ -82,6 +82,15 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
 
     abstract String assembleArchiveName();
 
+    private static InetAddress getLocalHost() {
+        try {
+            return InetAddress.localHost
+        } catch (UnknownHostException ignore) {
+            byte[] loopbackAddress = [127, 0, 0, 1]
+            return InetAddress.getByAddress("localhost", loopbackAddress)
+        }
+    }
+    
     protected static String getLocalHostName() {
         try {
             return machineAddress.hostName

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -26,14 +26,13 @@ import org.gradle.api.tasks.bundling.AbstractArchiveTask
 
 public abstract class SystemPackagingTask extends AbstractArchiveTask {
     private static Logger logger = Logging.getLogger(SystemPackagingTask);
+    private static final String hostName = getLocalHostName()
 
     @Delegate
     @Nested
     SystemPackagingExtension exten // Not File extension or ext list of properties, different kind of Extension
 
     ProjectPackagingExtension parentExten
-
-    static InetAddress machineAddress = getLocalHost()
 
     // TODO Add conventions to pull from extension
 
@@ -64,7 +63,7 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
         mapping.map('user', { parentExten?.getUser()?:getPackager() })
         mapping.map('permissionGroup', { parentExten?.getPermissionGroup()?:'' })
         mapping.map('packageGroup', { parentExten?.getPackageGroup() })
-        mapping.map('buildHost', { parentExten?.getBuildHost()?:getLocalHostName() })
+        mapping.map('buildHost', { parentExten?.getBuildHost()?:hostName })
         mapping.map('summary', { parentExten?.getSummary()?:getPackageName() })
         mapping.map('packageDescription', { parentExten?.getPackageDescription()?:project.getDescription() })
         mapping.map('license', { parentExten?.getLicense()?:'' })
@@ -82,18 +81,9 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
 
     abstract String assembleArchiveName();
 
-    private static InetAddress getLocalHost() {
-        try {
-            return InetAddress.localHost
-        } catch (UnknownHostException ignore) {
-            byte[] loopbackAddress = [127, 0, 0, 1]
-            return InetAddress.getByAddress("localhost", loopbackAddress)
-        }
-    }
-    
     protected static String getLocalHostName() {
         try {
-            return machineAddress.hostName
+            return InetAddress.localHost.hostName
         } catch (UnknownHostException ignore) {
             return "unknown"
         }

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -251,32 +251,6 @@ class RpmPluginTest extends ProjectSpec {
         scannerApple.asString() == '/usr/local/myproduct/apple'
     }
 
-    def 'buildHost_shouldHaveASensibleDefault'() {
-        setup:
-        InetAddress mockInetAddress = Mock()
-        mockInetAddress.hostName >> { throw new UnknownHostException() }
-
-        File srcDir = new File(projectDir, 'src')
-        srcDir.mkdirs()
-        FileUtils.writeStringToFile(new File(srcDir, 'apple'), 'apple')
-
-        when:
-        project.apply plugin: 'rpm'
-
-        Rpm rpmTask = (Rpm) project.task([type: Rpm], 'buildRpm', {})
-        SystemPackagingTask.machineAddress = mockInetAddress
-
-        then:
-        'unknown' == rpmTask.getBuildHost()
-
-        when:
-        rpmTask.execute()
-
-        then:
-        noExceptionThrown()
-
-    }
-
     def 'usesArchivesBaseName'() {
 
         // archivesBaseName is an artifact of the BasePlugin, and won't exist until it's applied.


### PR DESCRIPTION
I removed the InetAddress.localHost lookup that was assigned to SystemPackagingTask.machineAddress.  SystemPackagingTask now has a String for holding the hostname which is looked up in getLocalHostName() which handles any possible UnknownHostExceptions and just returns 'unknown'.  This is only an issue on hosts with their hostname set to an invalid value. 