### PR TITLE
Avoid "Cannot invoke method toLowerCase() on null object" if arch is set...

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
@@ -44,7 +44,7 @@ class Rpm extends SystemPackagingTask {
 
     @Override
     protected String getArchString() {
-        return arch?.name().toLowerCase();
+        return arch?.name()?.toLowerCase();
     }
 
     @Override


### PR DESCRIPTION
... to null on buildRpm task