### PR TITLE
Fixed rpm task on hosts with incorrect hostname. Opened against branch '...

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -19,21 +19,17 @@ package com.netflix.gradle.plugins.packaging
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
-import org.gradle.api.logging.Logger
-import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 
 public abstract class SystemPackagingTask extends AbstractArchiveTask {
-    private static Logger logger = Logging.getLogger(SystemPackagingTask);
+    private static final String HOST_NAME = getLocalHostName()
 
     @Delegate
     @Nested
     SystemPackagingExtension exten // Not File extension or ext list of properties, different kind of Extension
 
     ProjectPackagingExtension parentExten
-
-    static InetAddress machineAddress = InetAddress.localHost
 
     // TODO Add conventions to pull from extension
 
@@ -65,7 +61,7 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
         mapping.map('user', { parentExten?.getUser()?:getPackager() })
         mapping.map('permissionGroup', { parentExten?.getPermissionGroup()?:'' })
         mapping.map('packageGroup', { parentExten?.getPackageGroup() })
-        mapping.map('buildHost', { parentExten?.getBuildHost()?:getLocalHostName() })
+        mapping.map('buildHost', { parentExten?.getBuildHost()?: HOST_NAME })
         mapping.map('summary', { parentExten?.getSummary()?:getPackageName() })
         mapping.map('packageDescription', { parentExten?.getPackageDescription()?:project.getDescription() })
         mapping.map('license', { parentExten?.getLicense()?:'' })
@@ -83,9 +79,9 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
 
     abstract String assembleArchiveName();
 
-    protected static String getLocalHostName() {
+    private static String getLocalHostName() {
         try {
-            return machineAddress.hostName
+            return InetAddress.localHost.hostName
         } catch (UnknownHostException ignore) {
             return "unknown"
         }

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -18,7 +18,6 @@ package com.netflix.gradle.plugins.rpm
 
 import com.google.common.io.Files
 import com.netflix.gradle.plugins.packaging.ProjectPackagingExtension
-import com.netflix.gradle.plugins.packaging.SystemPackagingTask
 import com.netflix.gradle.plugins.utils.JavaNIOUtils
 import nebula.test.ProjectSpec
 import nebula.test.dependencies.DependencyGraph
@@ -250,32 +249,6 @@ class RpmPluginTest extends ProjectSpec {
         def scan = Scanner.scan(rpmTask.getArchivePath())
         def scannerApple = scan.files.find { it.name =='./usr/local/myproduct/bin/apple'}
         scannerApple.asString() == '/usr/local/myproduct/apple'
-    }
-
-    def 'buildHost_shouldHaveASensibleDefault'() {
-        setup:
-        InetAddress mockInetAddress = Mock()
-        mockInetAddress.hostName >> { throw new UnknownHostException() }
-
-        File srcDir = new File(projectDir, 'src')
-        srcDir.mkdirs()
-        FileUtils.writeStringToFile(new File(srcDir, 'apple'), 'apple')
-
-        when:
-        project.apply plugin: 'rpm'
-
-        Rpm rpmTask = (Rpm) project.task([type: Rpm], 'buildRpm', {})
-        SystemPackagingTask.machineAddress = mockInetAddress
-
-        then:
-        'unknown' == rpmTask.getBuildHost()
-
-        when:
-        rpmTask.execute()
-
-        then:
-        noExceptionThrown()
-
     }
 
     def 'usesArchivesBaseName'() {


### PR DESCRIPTION
...gradle-2.2' (see pull request #71).