### PR TITLE
Fixes #96. Pass an empty Depends to jdeb so it doesn't append 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.2.6 / 2015-05-08
+------------------
+
+* Pass an empty depends to jdeb so it doesn't append default-jre | java6-runtime to debians Depend section
+
 2.2.5 / 2015-05-06
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Gradle requires that plugins be added to the classpath as part of the classpath.
 
 ```groovy
 plugins {
-  id "nebula.os-package" version "2.2.5"
+  id "nebula.os-package" version "2.2.6"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories { jcenter() }
-    dependencies { classpath 'com.netflix.nebula:nebula-plugin-plugin:2.0.+' }
+    dependencies { classpath 'com.netflix.nebula:nebula-plugin-plugin:2.2.+' }
 }
 
 description 'Provides a task similar to Tar and Zip for constructing RPM and DEB package files.'
@@ -53,5 +53,9 @@ contacts {
     'alan@trigonic.com' {
         moniker 'Alan Krueger'
         github 'AlanKrueger'
+    }
+    'rob.spieldenner@gmail.com' {
+        moniker 'Rob Spieldenner'
+        github 'rspieldenner'
     }
 }

--- a/src/main/resources/deb/control.ftl
+++ b/src/main/resources/deb/control.ftl
@@ -10,8 +10,8 @@ Provides: ${provides}
 Homepage: ${url}
 Architecture: ${arch}
 Distribution: ${distribution}<% if (multiArch) { %>
-Multi-Arch: ${multiArch}<% } %><% if (depends) { %>
-Depends: ${depends}<% } %><% if (conflicts) { %>
+Multi-Arch: ${multiArch}<% } %>
+Depends: ${depends}<% if (conflicts) { %>
 Conflicts: ${conflicts}<% } %><% if (replaces) { %>
 Replaces: ${replaces}<% } %><% if (recommends) { %>
 Recommends: ${recommends}<% } %><% if (suggests) { %>

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/TemplateHelperSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/TemplateHelperSpec.groovy
@@ -51,7 +51,7 @@ class TemplateHelperSpec extends Specification {
         then:
         resultFile.exists()
         resultFile.text.contains('Architecture: Arch')
-        !resultFile.text.contains('Depends')
+        resultFile.text.contains('Depends')
         !resultFile.text.contains('Multi-Arch')
     }
 


### PR DESCRIPTION
bad depends.

Also verified that jdeb does omit the empty depends block from the final debian