### PR TITLE
Can add supplementary files to debian control

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -278,7 +278,7 @@ class DebCopyAction extends AbstractPackagingCopyAction {
                 }
         debianFiles.addAll(addlFiles)
 
-        (debTask.allSupplementaryControlFiles - null).each { supControl ->
+        debTask.allSupplementaryControlFiles.each { supControl ->
             def supControlFile = supControl instanceof File ? supControl : debTask.project.file(supControl)
             new File(debianDir, supControlFile.name).bytes = supControlFile.bytes
         }

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -278,6 +278,11 @@ class DebCopyAction extends AbstractPackagingCopyAction {
                 }
         debianFiles.addAll(addlFiles)
 
+        (debTask.allSupplementaryControlFiles - null).each { supControl ->
+            def supControlFile = supControl instanceof File ? supControl : debTask.project.file(supControl)
+            new File(debianDir, supControlFile.name).bytes = supControlFile.bytes
+        }
+
         DebMaker maker = new DebMaker(new GradleLoggerConsole(), dataProducers, null)
         File contextFile = templateHelper.generateFile("control", context)
         maker.setControl(contextFile.parentFile)

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -135,6 +135,19 @@ class SystemPackagingExtension {
     @Input @Optional
     String priority
 
+    @Input Optional
+    final List<Object> supplementaryControlFiles = []
+
+    def supplementaryControl(String file) {
+        supplementaryControlFiles << file
+        return this
+    }
+
+    def supplementaryControl(File file) {
+        supplementaryControlFiles << file
+        return this
+    }
+
     // Scripts
 
     final List<Object> configurationFiles = []

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -135,7 +135,7 @@ class SystemPackagingExtension {
     @Input @Optional
     String priority
 
-    @Input Optional
+    @Input @Optional
     final List<Object> supplementaryControlFiles = []
 
     def supplementaryControl(String file) {

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -142,6 +142,11 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
     }
 
     @Input @Optional
+    def getAllSupplementaryControlFiles() {
+        return getSupplementaryControlFiles() + parentExten?.getSupplementaryControlFiles()
+    }
+
+    @Input @Optional
     List<Link> getAllLinks() {
         if(parentExten) {
             return getLinks() + parentExten.getLinks()

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -143,7 +143,7 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
 
     @Input @Optional
     def getAllSupplementaryControlFiles() {
-        return getSupplementaryControlFiles() + parentExten?.getSupplementaryControlFiles()
+        return getSupplementaryControlFiles() + ( parentExten?.getSupplementaryControlFiles() ?: [] )
     }
 
     @Input @Optional

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -844,4 +844,29 @@ class DebPluginTest extends ProjectSpec {
         appleFile.userName == 'me'
         appleFile.groupName == 'awesome'
     }
+
+    @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/109")
+    def "Can add supplementary files to debian control"() {
+        given:
+        File srcDir = new File(projectDir, 'src')
+        srcDir.mkdirs()
+        FileUtils.writeStringToFile(new File(srcDir,'changelog'), 'This is a changelog file')
+        FileUtils.writeStringToFile(new File(srcDir,'something'), 'This is a something file')
+
+        project.apply plugin: 'deb'
+
+        Deb debTask = project.task('buildDeb', type: Deb) {
+            packageName = 'supplementary-files-in-debian-control'
+            supplementaryControl project.file('src/changelog')
+            supplementaryControl 'src/something'
+        }
+
+        when:
+        debTask.execute()
+
+        then:
+        def scan = new Scanner(debTask.archivePath)
+        scan.getControl('./changelog')
+        scan.getControl('./something')
+    }
 }


### PR DESCRIPTION
Regarding #109 here is a PR allowing to add arbitrary files to the debian control directory.
For example, using this, one is able to put a `changelog` file in there.

Please tell me if you're willing to merge this and if more changes are needed.

Cheers
