### PR TITLE
Fix jdeb log levels

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -302,7 +302,7 @@ class DebCopyAction extends AbstractPackagingCopyAction {
     private static class GradleLoggerConsole implements Console {
         @Override
         void debug(String message) {
-            logger.warn(message)
+            logger.debug(message)
         }
 
         @Override


### PR DESCRIPTION
The console object introduced in fdb9d79 sent jdeb's debug messages as 'warn' messages. This output includes a detailed file listing and becomes very verbose. For one of our projects we were getting 16MB of output when building a deb.