### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ buildRpm {
     ospackage {
         packageName = 'foo'
         version = '1.2.3'
-        release = 1
+        release = '1'
         arch = I386
         os = LINUX
 


### PR DESCRIPTION
Docs fix.  The 'release'  method requires a string, otherwise gradle produces a very confusing message.