### PR TITLE
deb package name validation fails when it should pass

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameAttributeValidator.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameAttributeValidator.groovy
@@ -28,7 +28,7 @@ class DebPackageNameAttributeValidator implements SystemPackagingAttributeValida
     }
 
     private boolean matchesExpectedCharacters(String packageName) {
-        packageName ==~ /[a-z0-9.+-]+/
+        packageName ==~ /[A-Za-z0-9.+-]+/
     }
 
     @Override


### PR DESCRIPTION
closes #126 validation for package name fails with names that have uppercase letters even though it should be allowed