### PR TITLE
Debian package improvement

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -105,7 +105,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
 
         String user = lookup(specToLookAt, 'user') ?: task.user
         Integer uid = (Integer) lookup(specToLookAt, 'uid') ?: task.uid ?: 0
-        String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
+        String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup ?: user
         Integer gid = (Integer) lookup(specToLookAt, 'gid') ?: task.gid ?: 0
 
         int fileMode = fileDetails.mode
@@ -122,7 +122,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
             logger.debug "adding directory {}", dirDetails.relativePath.pathString
             String user = lookup(specToLookAt, 'user') ?: task.user
             Integer uid = (Integer) lookup(specToLookAt, 'uid') ?: task.uid ?: 0
-            String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
+            String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup ?: user
             Integer gid = (Integer) lookup(specToLookAt, 'gid') ?: task.gid ?: 0
 
             int fileMode = dirDetails.mode

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -72,7 +72,7 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
         mapping.map('signingKeyRingFile', {
             parentExten?.getSigningKeyRingFile()?:new File(System.getProperty('user.home').toString(), '.gnupg/secring.gpg')
         })
-        mapping.map('user', { parentExten?.getUser()?:getPackager() })
+        mapping.map('user', { parentExten?.getUser()?:'root' })
         mapping.map('maintainer', { parentExten?.getMaintainer()?:getPackager() })
         mapping.map('uploaders', { parentExten?.getUploaders()?:getPackager() })
         mapping.map('permissionGroup', { parentExten?.getPermissionGroup()?:'' })

--- a/src/main/resources/deb/postinst.ftl
+++ b/src/main/resources/deb/postinst.ftl
@@ -7,14 +7,6 @@ ec() {
 
 case "\$1" in
     configure)
-        <% dirs.each{ dir -> %>
-        <% if (dir['owner']) { %>
-            ec install -o <%= dir['owner'] %> -d <%= dir['name'] %>
-        <% } else { %>
-            ec install -d <%= dir['name'] %>
-        <% } %>
-        <% } %>
-
         <% commands.each {command -> %>
         <%= command %>
         <% } %>


### PR DESCRIPTION
Changes:
- Use file owner group name same as owner user name by default
- Package all files root-owner by default
- Remove install command from postinst script
