### PR TITLE
fixed: no capitals are usable in debian package names

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameAttributeValidator.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameAttributeValidator.groovy
@@ -28,7 +28,7 @@ class DebPackageNameAttributeValidator implements SystemPackagingAttributeValida
     }
 
     private boolean matchesExpectedCharacters(String packageName) {
-        packageName ==~ /[a-z0-9.+-]+/
+        packageName ==~ /[A-Za-z0-9.+-]+/
     }
 
     @Override

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameAttributeValidator.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameAttributeValidator.groovy
@@ -28,11 +28,11 @@ class DebPackageNameAttributeValidator implements SystemPackagingAttributeValida
     }
 
     private boolean matchesExpectedCharacters(String packageName) {
-        packageName ==~ /[A-Za-z0-9.+-]+/
+        packageName ==~ /[a-z0-9.+-]+/
     }
 
     @Override
     String getErrorMessage(String attribute) {
-        "Invalid package name '$attribute' - a valid package name must start with an alphanumeric character, have a length of at least two characters and only contain [A-Za-z0-9.+-]"
+        "Invalid package name '$attribute' - a valid package name must start with an alphanumeric character, have a length of at least two characters and only contain [a-z0-9.+-]"
     }
 }

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameValidatorTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameValidatorTest.groovy
@@ -33,6 +33,6 @@ class DebPackageNameValidatorTest extends Specification {
         String errorMessage = validator.getErrorMessage('a')
 
         then:
-        errorMessage == "Invalid package name 'a' - a valid package name must start with an alphanumeric character, have a length of at least two characters and only contain [A-Za-z0-9.+-]"
+        errorMessage == "Invalid package name 'a' - a valid package name must start with an alphanumeric character, have a length of at least two characters and only contain [a-z0-9.+-]"
     }
 }

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameValidatorTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameValidatorTest.groovy
@@ -22,7 +22,7 @@ class DebPackageNameValidatorTest extends Specification {
         'my.awesome.package' | true   | 'package with dot characters'
         'my-awesome-package' | true   | 'package with dash characters'
         'my+awesome+package' | true   | 'package with plus characters'
-        'My-Awesome-Package' | true   | 'package with upper case characters'
+        'My-Awesome-Package' | false  | 'package with upper case characters'
         'a'                  | false  | 'package name too short'
         '-abc'               | false  | 'package name does not start with alphanumeric character'
         'abc^'               | false  | 'package name with an invalid character'

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameValidatorTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/validation/DebPackageNameValidatorTest.groovy
@@ -22,7 +22,7 @@ class DebPackageNameValidatorTest extends Specification {
         'my.awesome.package' | true   | 'package with dot characters'
         'my-awesome-package' | true   | 'package with dash characters'
         'my+awesome+package' | true   | 'package with plus characters'
-        'My-Awesome-Package' | false  | 'package with upper case characters'
+        'My-Awesome-Package' | true   | 'package with upper case characters'
         'a'                  | false  | 'package name too short'
         '-abc'               | false  | 'package name does not start with alphanumeric character'
         'abc^'               | false  | 'package name with an invalid character'

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/validation/DebTaskPropertiesValidatorIntegrationTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/validation/DebTaskPropertiesValidatorIntegrationTest.groovy
@@ -68,6 +68,6 @@ class DebTaskPropertiesValidatorIntegrationTest extends ProjectSpec {
 
         then:
         Throwable t = thrown(InvalidUserDataException)
-        t.message == "Invalid package name 'a' - a valid package name must start with an alphanumeric character, have a length of at least two characters and only contain [A-Za-z0-9.+-]"
+        t.message == "Invalid package name 'a' - a valid package name must start with an alphanumeric character, have a length of at least two characters and only contain [a-z0-9.+-]"
     }
 }


### PR DESCRIPTION
Hello,

I discovered that no debian packages with a name including capital letters like `foo-BAR` returns the error:
> Invalid package name 'foo-BAR' - a valid package name must start with an alphanumeric character, have a length of at least two characters and only contain [A-Za-z0-9.+-]
In the error it is stated, that it is valid to use capital letters. 
Because of that I fixed to regex to validate them as well. 

Regards