### PR TITLE
#148 - make provides accept multiple values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ apply from: 'https://raw.githubusercontent.com/nebula-plugins/nebula-core/b676bb
 
 dependencies {
     compile 'org.apache.commons:commons-lang3:3.1'
-    compile('org.redline-rpm:redline:1.2.1') {
+    compile('org.redline-rpm:redline:1.2.2') {
         // Where logging goes is a runtime decision
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -52,6 +52,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
     List<String> preDepends
     List<String> breaks
     List<String> replaces
+    List<String> provides
     List<DataProducer> dataProducers
     List<InstallDir> installDirs
     TemplateHelper templateHelper
@@ -71,6 +72,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         replaces = []
         dataProducers = []
         installDirs = []
+        provides = []
         debianDir = new File(task.project.buildDir, "debian")
         templateHelper = new TemplateHelper(debianDir, '/deb')
         debFileVisitorStrategy = new DebFileVisitorStrategy(dataProducers, installDirs)
@@ -139,6 +141,11 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
     @Override
     protected void addConflict(Dependency dep) {
         conflicts << dep.toDebString()
+    }
+
+    @Override
+    protected void addProvides(Dependency dep) {
+        provides << dep.packageName
     }
 
     @Override
@@ -308,7 +315,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
                 summary: task.getSummary(),
                 section: task.getPackageGroup(),
                 time: DateFormatUtils.SMTP_DATETIME_FORMAT.format(new Date()),
-                provides: task.getProvides(),
+                provides: StringUtils.join(provides, ", "),
                 depends: StringUtils.join(dependencies, ", "),
                 url: task.getUrl(),
                 arch: task.getArchString(),

--- a/src/main/groovy/com/netflix/gradle/plugins/docker/DockerCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/docker/DockerCopyAction.groovy
@@ -42,6 +42,9 @@ class DockerCopyAction extends AbstractPackagingCopyAction<SystemPackageDockerfi
     protected void addDirectory(Directory directory) {}
 
     @Override
+    protected void addProvides(Dependency dependency) {}
+
+    @Override
     protected void end() {
         dockerfileInstructionManager.create(task.archivePath)
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/AbstractPackagingCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/AbstractPackagingCopyAction.groovy
@@ -64,12 +64,13 @@ public abstract class AbstractPackagingCopyAction<T extends SystemPackagingTask>
 
     protected abstract void visitDir(FileCopyDetailsInternal dirDetails, def specToLookAt)
     protected abstract void visitFile(FileCopyDetailsInternal fileDetails, def specToLookAt)
-    protected abstract void addLink(Link link);
-    protected abstract void addDependency(Dependency dependency);
-    protected abstract void addConflict(Dependency dependency);
-    protected abstract void addObsolete(Dependency dependency);
+    protected abstract void addLink(Link link)
+    protected abstract void addDependency(Dependency dependency)
+    protected abstract void addConflict(Dependency dependency)
+    protected abstract void addObsolete(Dependency dependency)
+    protected abstract void addProvides(Dependency dependency)
     protected abstract void addDirectory(Directory directory)
-    protected abstract void end();
+    protected abstract void end()
 
     void startVisit(CopyAction action) {
         // Delay reading destinationDir until we start executing
@@ -95,6 +96,11 @@ public abstract class AbstractPackagingCopyAction<T extends SystemPackagingTask>
         for (Dependency conflict : task.getAllConflicts()) {
             logger.debug "adding conflicts on {} {}", conflict.packageName, conflict.version
             addConflict conflict
+        }
+
+        for (Dependency provides : task.getAllProvides()) {
+            logger.debug "adding provides on {} {}", provides.packageName, provides.version
+            addProvides(provides)
         }
 
         task.directories.each { directory ->

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -75,9 +75,6 @@ class SystemPackagingExtension {
     @Input @Optional
     String sourcePackage
 
-    @Input @Optional
-    String provides
-
     // For Backward compatibility for those that passed in a Architecture object
     String archStr // This is what can be convention mapped and then referenced
 
@@ -283,6 +280,7 @@ class SystemPackagingExtension {
     List<Dependency> preDepends = new ArrayList<Dependency>()
     List<Dependency> breaks = new ArrayList<Dependency>()
     List<Dependency> replaces = new ArrayList<Dependency>()
+    List<Dependency> provides = new ArrayList<Dependency>()
 
     Dependency requires(String packageName, String version, int flag) {
         def dep = new Dependency(packageName, version, flag)
@@ -372,6 +370,16 @@ class SystemPackagingExtension {
 
     Dependency replaces(String packageName) {
         replaces(packageName, '', 0)
+    }
+
+    Dependency provides(String packageName, String version, int flag) {
+        def dep = new Dependency(packageName, version, flag)
+        provides.add(dep)
+        dep
+    }
+
+    Dependency provides(String packageName) {
+        provides(packageName, '', 0)
     }
 
     List<Directory> directories = new ArrayList<Directory>()

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -180,14 +180,11 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
 
     @Input @Optional
     List<Dependency> getAllProvides() {
-        Dependency thisPackage = new Dependency(getPackageName(), '', 0)
-        List<Dependency> provides = new ArrayList<Dependency>()
-        provides.add(thisPackage)
-        provides += getProvides()
         if (parentExten) {
-            provides += parentExten.getProvides()
+            return parentExten.getProvides() + getProvides()
+        } else {
+            return getProvides()
         }
-        return provides.unique()
     }
 
     @Input @Optional

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -84,7 +84,6 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
         mapping.map('vendor', { parentExten?.getVendor()?:'' })
         mapping.map('url', { parentExten?.getUrl()?:'' })
         mapping.map('sourcePackage', { parentExten?.getSourcePackage()?:'' })
-        mapping.map('provides', { parentExten?.getProvides()?:getPackageName() })
         mapping.map('createDirectoryEntry', { parentExten?.getCreateDirectoryEntry()?:false })
         mapping.map('priority', { parentExten?.getPriority()?:'optional' })
 
@@ -177,6 +176,18 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
         } else {
             return getPrefixes()
         }
+    }
+
+    @Input @Optional
+    List<Dependency> getAllProvides() {
+        Dependency thisPackage = new Dependency(getPackageName(), '', 0)
+        List<Dependency> provides = new ArrayList<Dependency>()
+        provides.add(thisPackage)
+        provides += getProvides()
+        if (parentExten) {
+            provides += parentExten.getProvides()
+        }
+        return provides.unique()
     }
 
     @Input @Optional

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -66,7 +66,6 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
         builder.setDistribution task.distribution
         builder.setVendor task.vendor
         builder.setUrl task.url
-        builder.setProvides task.provides
         if (task.allPrefixes) {
             builder.setPrefixes(task.allPrefixes as String[])
         }
@@ -144,6 +143,11 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
     @Override
     protected void addObsolete(Dependency dep) {
         builder.addObsoletes(dep.packageName, dep.flag, dep.version)
+    }
+
+    @Override
+    protected void addProvides(Dependency dep) {
+        builder.addProvides(dep.packageName, dep.version, dep.flag)
     }
 
     @Override

--- a/src/main/resources/deb/control.ftl
+++ b/src/main/resources/deb/control.ftl
@@ -5,8 +5,8 @@ Maintainer: ${maintainer}
 Uploaders: ${uploaders}
 Version: ${fullVersion}
 Standards-Version: 3.8.3
-Package: ${name}
-Provides: ${provides}
+Package: ${name}<% if (provides) { %>
+Provides: ${provides}<% } %>
 Homepage: ${url}
 Architecture: ${arch}
 Distribution: ${distribution}<% if (multiArch) { %>

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -128,7 +128,6 @@ class DebPluginTest extends ProjectSpec {
         def scan = new Scanner(project.file('build/tmp/DebPluginTest/bleah_1.0-1_amd64.deb'))
         'bleah' == scan.getHeaderEntry('Package')
         'blarg (>= 1.0), blech' ==  scan.getHeaderEntry('Depends')
-        'bleah' == scan.getHeaderEntry('Provides')
         'Bleah blarg\n Not a very interesting library.' == scan.getHeaderEntry('Description')
         'http://www.example.com/' == scan.getHeaderEntry('Homepage')
         'Superman' == scan.getHeaderEntry('Maintainer')
@@ -986,7 +985,6 @@ class DebPluginTest extends ProjectSpec {
 
         then:
         def scan = new Scanner(debTask.archivePath)
-        def expectedHeader = "${debTask.packageName}, someVirtualPackage, someOtherVirtualPackage" as String
-        expectedHeader == scan.getHeaderEntry('Provides')
+        'someVirtualPackage, someOtherVirtualPackage' == scan.getHeaderEntry('Provides')
     }
 }

--- a/src/test/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingBasePluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingBasePluginTest.groovy
@@ -74,6 +74,7 @@ class SystemPackagingBasePluginTest extends ProjectSpec {
         when:
         ProjectPackagingExtension ext = project.getConvention().getByType(ProjectPackagingExtension)
         ext.with {
+            provides project.name
             release = 3
             requires 'awesomesauce'
             url 'http://notawesome.com'
@@ -104,6 +105,7 @@ class SystemPackagingBasePluginTest extends ProjectSpec {
         '3' == Scanner.getHeaderEntryString(rpmScanner, RELEASE)
         Scanner.getHeaderEntryString(rpmScanner, REQUIRENAME).contains('awesomesauce')
         'i386' == Scanner.getHeaderEntryString(rpmScanner, ARCH)
+        'execute-both-tasks' == Scanner.getHeaderEntryString(rpmScanner, PROVIDENAME)
         ['./opt/bleah', './opt/bleah/apple'] == rpmScanner.files*.name
 
     }

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -1105,4 +1105,27 @@ class RpmPluginTest extends ProjectSpec {
         '1.0.0-rc.1'         | '1.0.0~rc.1'
         '1.0.0-dev.3+abc219' | '1.0.0~dev.3'
     }
+
+    @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/148")
+    def 'handles multiple provides'() {
+        given:
+        project.apply plugin: 'nebula.rpm'
+        project.version = '1.0'
+
+        project.task([type: Rpm], 'buildRpm', {
+            destinationDir = project.file('build/tmp/RpmPluginTest')
+            destinationDir.mkdirs()
+            packageName = 'providesTest'
+            provides 'foo'
+            provides 'bar'
+        })
+
+        when:
+        project.tasks.buildRpm.execute()
+
+        then:
+        def scan = Scanner.scan(project.file('build/tmp/RpmPluginTest/providesTest-1.0.noarch.rpm'))
+        def provides = Scanner.getHeaderEntry(scan, PROVIDENAME)
+        ['foo', 'bar'].every { it in provides.values }
+    }
 }


### PR DESCRIPTION
FIxes #148 
Changes the behavior of the provides directive to build a list and provide that as a comma-delimited list in the resultant spec and control files for RPMs and DEBs respectively.

This does not currently allow for the RPM ability to declare a version along with the package name. DEB packages do not take a version in provides (provides is commonly used to provide "virtual packages" that allow multiple packages to satisfy a single dependency. eg vim, nvim, neovim, may all declare that they provide "vi" and "editor", and one may declare a dependency on that virtual package to ensure at least ONE of those choices is installed).

This no longer adds the package being built to the Provides: field as packages implicitly provide themselves

cc @rspieldenner @jkschneider @DanielThomas @nadavc 