### PR TITLE
Add missing requires() method

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -132,7 +132,7 @@ class SystemPackagingExtension {
 
     @Input @Optional
     String uploaders
-    
+
     @Input @Optional
     String priority
 
@@ -297,6 +297,10 @@ class SystemPackagingExtension {
         def dep = new Dependency(packageName, version, flag)
         dependencies.add(dep)
         dep
+    }
+
+    Dependency requires(String packageName, String version){
+        requires(packageName, version, 0)
     }
 
     Dependency requires(String packageName) {

--- a/src/test/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtensionTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtensionTest.groovy
@@ -20,6 +20,21 @@ class SystemPackagingExtensionTest extends Specification {
         dep.flag == 0
     }
 
+    def "Can define required package name with version and without flag"(){
+        given:
+        String packageName = 'myPackage'
+
+        when:
+        extension.requires(packageName, '1.0.0')
+
+        then:
+        extension.dependencies.size() == 1
+        Dependency dep = extension.dependencies[0]
+        dep.packageName == packageName
+        dep.version == '1.0.0'
+        dep.flag == 0
+    }
+
     def "Can define required package name with version and flag"() {
         given:
         String packageName = 'myPackage'


### PR DESCRIPTION
This pull request adds the documented but missing method
`requires(String packageName, String version)` to 
`com.netflix.gradle.plugins.packaging.SystemPackagingExtension` closes #169