### PR TITLE
Remove duplication of prefixes in rpm

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -187,7 +187,7 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
     @Input @Optional
     def getAllPrefixes() {
         if(parentExten) {
-            return getPrefixes() + parentExten.getPrefixes()
+            return (getPrefixes() + parentExten.getPrefixes()).unique()
         } else {
             return getPrefixes()
         }


### PR DESCRIPTION
Fix for issue #174 
I made several test and looks like all works fine.
