### PR TITLE
Fix Link class to be usable as task input

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/Link.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/Link.groovy
@@ -16,6 +16,9 @@
 
 package com.netflix.gradle.plugins.packaging
 
+import groovy.transform.EqualsAndHashCode
+
+@EqualsAndHashCode
 class Link implements Serializable {
     String path
     String target


### PR DESCRIPTION
The Link class required equals and hashcode to be usable
with task inputs. It would cause perpetual out-of-date
condition for tasks where symlinks were declared in the
package definition.