### PR TITLE
Enable alternative dependencies for debian

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/Dependency.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/Dependency.groovy
@@ -26,12 +26,18 @@ class Dependency implements Serializable {
     String packageName
     String version
     int flag = 0
+    Dependency alternative = null
 
     Dependency(String packageName, String version, int flag=0) {
         assert !packageName.contains(','), "Package name ($packageName) can not include commas"
         this.packageName = packageName
         this.version = version
         this.flag = flag
+    }
+
+    Dependency or(String packageName, String version='', int flag=0) {
+        alternative = new Dependency(packageName, version, flag)
+        alternative
     }
 
     String toDebString() {
@@ -52,6 +58,9 @@ class Dependency implements Serializable {
             depStr += " (${sign} ${this.version})"
         } else if (this.version) {
             depStr += " (${this.version})"
+        }
+        if (alternative) {
+            depStr += " | " + alternative.toDebString()
         }
         depStr
     }

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -1063,6 +1063,22 @@ class DebPluginTest extends ProjectSpec {
         taskA.getAllDependencies() == taskB.getAllDependencies()
     }
 
+    def 'add alternative dependencies' () {
+        given:
+        project.apply plugin: 'nebula.deb'
+        Deb debTask = project.task('buildDeb', type: Deb) {
+            requires('depA', '1.0').or('depB', '2.0', Flags.GREATER | Flags.EQUAL)
+            requires('depC', '3.0').or('depD')
+        }
+
+        when:
+        debTask.execute()
+
+        then:
+        def scan = new Scanner(debTask.archivePath)
+        'depA (1.0) | depB (>= 2.0), depC (3.0) | depD' ==  scan.getHeaderEntry('Depends')
+    }
+
     @Issue("")
     def 'special characters in directory names'() {
         given:


### PR DESCRIPTION
It is possible for Debian package to have alternatives for dependencies. I don't know much about RPM, but I found info that although a similar feature has just appeared, its use is limited yet.

So I propose to support this feature for Debian now.