### PR TITLE
Allow Defining Complete Maintainer Scripts for Debian

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGenerator.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGenerator.groovy
@@ -31,13 +31,13 @@ class MaintainerScriptsGenerator {
                 new MaintainerScript("postrm", task.postUninstallFile, task.allPostUninstallCommands)
         ]
         def installUtils = task.allCommonCommands.collect { stripShebang(it) }
-        scripts.forEach({ script ->
+        for (script in scripts) {
             if(script.file) {
                 fileSystem.copy(script.file, new File(destination, script.name))
             } else {
                 templateHelper.generateFile(script.name, context + [commands: installUtils + script.commands.collect { stripShebang(it) }])
             }
-        })
+        }
     }
 
     /**

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGenerator.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGenerator.groovy
@@ -1,0 +1,67 @@
+package com.netflix.gradle.plugins.deb
+
+import com.netflix.gradle.plugins.utils.FileSystemActions
+import groovy.transform.Canonical
+
+class MaintainerScriptsGenerator {
+    private final Deb task
+    private final TemplateHelper templateHelper
+    private final File destination
+    private final FileSystemActions fileSystem
+
+    MaintainerScriptsGenerator(Deb task, TemplateHelper templateHelper, File destination, FileSystemActions fileSystem) {
+        this.destination = destination
+        this.task = task
+        this.templateHelper = templateHelper
+        this.fileSystem = fileSystem
+    }
+
+    void generate(Map<String, Object> context) {
+        templateHelper.generateFile("control", context)
+
+        def configurationFiles = task.allConfigurationFiles
+        if (configurationFiles.any()) {
+            templateHelper.generateFile("conffiles", [files: configurationFiles] )
+        }
+
+        def scripts = [
+                new MaintainerScript("preinst", task.preInstallFile, task.allPreInstallCommands),
+                new MaintainerScript("postinst", task.postInstallFile, task.allPostInstallCommands),
+                new MaintainerScript("prerm", task.preUninstallFile, task.allPreUninstallCommands),
+                new MaintainerScript("postrm", task.postUninstallFile, task.allPostUninstallCommands)
+        ]
+        def installUtils = task.allCommonCommands.collect { stripShebang(it) }
+        scripts.forEach({ script ->
+            if(script.file) {
+                fileSystem.copy(script.file, new File(destination, script.name))
+            } else {
+                templateHelper.generateFile(script.name, context + [commands: installUtils + script.commands.collect { stripShebang(it) }])
+            }
+        })
+    }
+
+    /**
+     * Works with nulls, Strings and Files.
+     *
+     * @param script
+     * @return
+     */
+    private static String stripShebang(Object script) {
+        StringBuilder result = new StringBuilder();
+        script?.eachLine { line ->
+            if (!line.matches('^#!.*$')) {
+                result.append line
+                result.append "\n"
+            }
+        }
+        result.toString()
+
+    }
+
+    @Canonical
+    private static class MaintainerScript {
+        String name
+        File file
+        List<Object> commands
+    }
+}

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/AbstractPackagingCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/AbstractPackagingCopyAction.groovy
@@ -138,24 +138,6 @@ public abstract class AbstractPackagingCopyAction<T extends SystemPackagingTask>
         result.toString()
     }
 
-    /**
-     * Works with nulls, Strings and Files.
-     *
-     * @param script
-     * @return
-     */
-    String stripShebang(Object script) {
-        StringBuilder result = new StringBuilder();
-        script?.eachLine { line ->
-            if (!line.matches('^#!.*$')) {
-                result.append line
-                result.append "\n"
-            }
-        }
-        result.toString()
-
-    }
-
     CopySpecInternal extractSpec(FileCopyDetailsInternal fileDetails) {
         if (fileDetails instanceof DefaultFileCopyDetails) {
             def startingClass = fileDetails.getClass() // It's in there somewhere

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -18,6 +18,15 @@ import org.gradle.api.tasks.Optional
  */
 
 class SystemPackagingExtension {
+    static final IllegalStateException MULTIPLE_PREINSTALL_FILES = multipleFilesDefined('PreInstall')
+    static final IllegalStateException MULTIPLE_POSTINSTALL_FILES = multipleFilesDefined('PostInstall')
+    static final IllegalStateException MULTIPLE_PREUNINSTALL_FILES = multipleFilesDefined('PreUninstall')
+    static final IllegalStateException MULTIPLE_POSTUNINSTALL_FILES = multipleFilesDefined('PostUninstall')
+    static final IllegalStateException PREINSTALL_COMMANDS_AND_FILE_DEFINED = conflictingDefinitions('PreInstall')
+    static final IllegalStateException POSTINSTALL_COMMANDS_AND_FILE_DEFINED = conflictingDefinitions('PostInstall')
+    static final IllegalStateException PREUNINSTALL_COMMANDS_AND_FILE_DEFINED = conflictingDefinitions('PreUninstall')
+    static final IllegalStateException POSTUNINSTALL_COMMANDS_AND_FILE_DEFINED = conflictingDefinitions('PostUninstall')
+
     // File name components
     @Input @Optional
     String packageName
@@ -149,6 +158,11 @@ class SystemPackagingExtension {
 
     // Scripts
 
+    File preInstallFile
+    File postInstallFile
+    File preUninstallFile
+    File postUninstallFile
+
     final List<Object> configurationFiles = []
 
     final List<Object> preInstallCommands = []
@@ -206,13 +220,21 @@ class SystemPackagingExtension {
     }
 
     def preInstall(String script) {
+        if(preInstallFile) { throw PREINSTALL_COMMANDS_AND_FILE_DEFINED }
         preInstallCommands << script
         return this
     }
 
     def preInstall(File script) {
+        if(preInstallFile) { throw PREINSTALL_COMMANDS_AND_FILE_DEFINED }
         preInstallCommands << script
         return this
+    }
+
+    def preInstallFile(File path) {
+        if(preInstallFile) { throw MULTIPLE_PREINSTALL_FILES }
+        if(preInstallCommands) { throw PREINSTALL_COMMANDS_AND_FILE_DEFINED }
+        preInstallFile = path
     }
 
     /**
@@ -224,15 +246,22 @@ class SystemPackagingExtension {
     }
 
     def postInstall(String script) {
+        if(postInstallFile) { throw POSTINSTALL_COMMANDS_AND_FILE_DEFINED }
         postInstallCommands << script
         return this
     }
 
     def postInstall(File script) {
+        if(postInstallFile) { throw POSTINSTALL_COMMANDS_AND_FILE_DEFINED }
         postInstallCommands << script
         return this
     }
 
+    def postInstallFile(File path) {
+        if(postInstallFile) { throw MULTIPLE_POSTINSTALL_FILES }
+        if(postInstallCommands) { throw POSTINSTALL_COMMANDS_AND_FILE_DEFINED }
+        postInstallFile = path
+    }
 
     /**
      * For backwards compatibility
@@ -243,13 +272,21 @@ class SystemPackagingExtension {
     }
 
     def preUninstall(String script) {
+        if(preUninstallFile) { throw PREUNINSTALL_COMMANDS_AND_FILE_DEFINED }
         preUninstallCommands << script
         return this
     }
 
     def preUninstall(File script) {
+        if(preUninstallFile) { throw PREUNINSTALL_COMMANDS_AND_FILE_DEFINED }
         preUninstallCommands << script
         return this
+    }
+
+    def preUninstallFile(File script) {
+        if(preUninstallFile) { throw MULTIPLE_PREUNINSTALL_FILES }
+        if(preUninstallCommands) { throw PREUNINSTALL_COMMANDS_AND_FILE_DEFINED }
+        preUninstallFile = script
     }
 
     /**
@@ -261,13 +298,21 @@ class SystemPackagingExtension {
     }
 
     def postUninstall(String script) {
+        if(postUninstallFile) { throw POSTUNINSTALL_COMMANDS_AND_FILE_DEFINED }
         postUninstallCommands << script
         return this
     }
 
     def postUninstall(File script) {
+        if(postUninstallFile) { throw POSTUNINSTALL_COMMANDS_AND_FILE_DEFINED }
         postUninstallCommands << script
         return this
+    }
+
+    def postUninstallFile(File script) {
+        if(postUninstallFile) { throw MULTIPLE_POSTUNINSTALL_FILES }
+        if(postUninstallCommands) { throw POSTUNINSTALL_COMMANDS_AND_FILE_DEFINED }
+        postUninstallFile = script
     }
 
     /**
@@ -466,4 +511,11 @@ class SystemPackagingExtension {
         return this
     }
 
+    private static IllegalStateException multipleFilesDefined(String fileName) {
+        new IllegalStateException("Cannot specify more than one $fileName File")
+    }
+
+    private static IllegalStateException conflictingDefinitions(String type) {
+        new IllegalStateException("Cannot specify $type File and $type Commands")
+    }
 }

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -53,6 +53,10 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
         super.startVisit(action)
 
         assert task.getVersion() != null, 'RPM requires a version string'
+        if ([task.preInstallFile, task.postInstallFile, task.preUninstallFile, task.postUninstallFile].any()) {
+            logger.warn('At least one of (preInstallFile|postInstallFile|preUninstallFile|postUninstallFile) is defined ' +
+                    'and will be ignored for RPM builds')
+        }
 
         builder = new Builder()
         builder.setPackage task.packageName, task.version, task.release, task.epoch

--- a/src/main/groovy/com/netflix/gradle/plugins/utils/ApacheCommonsFileSystemActions.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/utils/ApacheCommonsFileSystemActions.groovy
@@ -1,0 +1,10 @@
+package com.netflix.gradle.plugins.utils
+
+import org.apache.commons.io.FileUtils
+
+class ApacheCommonsFileSystemActions implements FileSystemActions {
+    @Override
+    void copy(File from, File to) {
+        FileUtils.copyFile(from, to)
+    }
+}

--- a/src/main/groovy/com/netflix/gradle/plugins/utils/FileSystemActions.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/utils/FileSystemActions.groovy
@@ -1,0 +1,5 @@
+package com.netflix.gradle.plugins.utils
+
+interface FileSystemActions {
+    void copy(File from, File to)
+}

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -212,6 +212,46 @@ class DebPluginTest extends ProjectSpec {
 
     }
 
+    def 'specify complete maintainer scripts'() {
+        given:
+        project.version = 1.0
+        File srcDir = new File(projectDir, 'src')
+        srcDir.mkdirs()
+        def customPreInst = new File(srcDir, 'some-preinst-file.py')
+        def customPreInstContents = '#!/usr/bin/env python3\nprint("Installing...")'
+        FileUtils.writeStringToFile(customPreInst, customPreInstContents)
+
+        def customPostInst = new File(srcDir, 'some-postinst-file.py')
+        def customPostInstContents = '#!/usr/bin/env python\nprint "Installed"'
+        FileUtils.writeStringToFile(customPostInst, customPostInstContents)
+
+        def customPreRm = new File(srcDir, 'some-prerm-file.sh')
+        def customPreRmContents = '#!/bin/bash \necho "Removing..."'
+        FileUtils.writeStringToFile(customPreRm, customPreRmContents)
+
+        def customPostRm = new File(srcDir, 'some-postrm-file.rb')
+        def customPostRmContents = '#!/usr/bin/env ruby\nputs "Uninstallation Completed." '
+        FileUtils.writeStringToFile(customPostRm, customPostRmContents)
+
+        project.apply plugin: 'nebula.deb'
+        Deb debTask = (Deb) project.task([type: Deb], 'buildDeb', {
+            preInstallFile customPreInst
+            postInstallFile customPostInst
+            preUninstallFile customPreRm
+            postUninstallFile customPostRm
+        })
+
+        when:
+        debTask.execute()
+
+        then:
+        def scan = new Scanner(debTask.getArchivePath())
+        scan.controlContents['./preinst'].contains(customPreInstContents)
+        scan.controlContents['./postinst'].contains(customPostInstContents)
+        scan.controlContents['./prerm'].contains(customPreRmContents)
+        scan.controlContents['./postrm'].contains(customPostRmContents)
+    }
+
     def 'generateScripts'() {
         project.version = 1.0
 

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGeneratorSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGeneratorSpec.groovy
@@ -1,0 +1,145 @@
+package com.netflix.gradle.plugins.deb
+
+import com.netflix.gradle.plugins.utils.FileSystemActions
+import nebula.test.ProjectSpec
+
+class MaintainerScriptsGeneratorSpec extends ProjectSpec {
+    FileSystemActions fileSystemActions
+    TemplateHelper templateHelper
+    Map<String, Object> context
+
+    def setup() {
+        fileSystemActions = Mock(FileSystemActions)
+        templateHelper = Mock(TemplateHelper)
+        context = [:]
+    }
+
+    def 'does not call templateHelper if preInstallFile defined'() {
+        given:
+        def source = new File('sample-script.sh')
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            preInstallFile = source
+        }) as Deb
+
+        def destination = new File('/tmp')
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, destination, fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        1 * fileSystemActions.copy(source, new File(destination, 'preinst'))
+        0 * templateHelper.generateFile('preinst', _ as Map<String, Object>)
+    }
+
+    def 'call templateHelper when no preInstallFile defined'() {
+        given:
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            preInstallFile = null
+        }) as Deb
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, new File('/tmp'), fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        0 * fileSystemActions.copy(_ as File, _ as File)
+        1 * templateHelper.generateFile('preinst', _ as Map<String, Object>)
+    }
+
+    def 'does not call templateHelper if postInstallFile defined'() {
+        given:
+        def source = new File('sample-script.sh')
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            postInstallFile = source
+        }) as Deb
+        def destination = new File('/tmp')
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, destination, fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        1 * fileSystemActions.copy(source, new File(destination, 'postinst'))
+        0 * templateHelper.generateFile('postinst', _ as Map<String, Object>)
+    }
+
+    def 'call templateHelper when no postInstallFile defined'() {
+        given:
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            postInstallFile = null
+        }) as Deb
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, new File('/tmp'), fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        0 * fileSystemActions.copy(_ as File, _ as File)
+        1 * templateHelper.generateFile('postinst', _ as Map<String, Object>)
+    }
+
+    def 'does not call templateHelper if preUninstallFile defined'() {
+        given:
+        def source = new File('sample-script.sh')
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            preUninstallFile = source
+        }) as Deb
+        def destination = new File('/tmp')
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, destination, fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        1 * fileSystemActions.copy(source, new File(destination, 'prerm'))
+        0 * templateHelper.generateFile('prerm', _ as Map<String, Object>)
+    }
+
+    def 'call templateHelper when no preUninstallFile defined'() {
+        given:
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            preUninstallFile = null
+        }) as Deb
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, new File('/tmp'), fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        0 * fileSystemActions.copy(_ as File, _ as File)
+        1 * templateHelper.generateFile('prerm', _ as Map<String, Object>)
+    }
+
+    def 'does not call templateHelper if postUninstallFile defined'() {
+        given:
+        def source = new File('sample-script.sh')
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            postUninstallFile = source
+        }) as Deb
+        def destination = new File('/tmp')
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, destination, fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        1 * fileSystemActions.copy(source, new File(destination, 'postrm'))
+        0 * templateHelper.generateFile('postrm', _ as Map<String, Object>)
+    }
+
+    def 'call templateHelper when no postUninstallFile defined'() {
+        given:
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            postUninstallFile = null
+        }) as Deb
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, new File('/tmp'), fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        0 * fileSystemActions.copy(_ as File, _ as File)
+        1 * templateHelper.generateFile('postrm', _ as Map<String, Object>)
+    }
+}

--- a/src/test/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtensionTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtensionTest.groovy
@@ -73,4 +73,244 @@ class SystemPackagingExtensionTest extends Specification {
         Throwable t = thrown(AssertionError)
         t.message == 'Package name (myPackage,something) can not include commas. Expression: packageName.contains(,)'
     }
+
+    def "Cannot define preInstallFile more than once"() {
+        given:
+        extension.preInstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.preInstallFile(new File('/tmp/some-other-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.MULTIPLE_PREINSTALL_FILES
+    }
+
+    def "Cannot define preInstallFile after preInstall string commands"() {
+        given:
+        extension.preInstall('echo "Done Installing..."')
+
+        when:
+        extension.preInstallFile(new File('/tmp/some-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.PREINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define preInstallFile after preInstall file commands"() {
+        given:
+        extension.preInstall(new File('/tmp/some-other-file'))
+
+        when:
+        extension.preInstallFile(new File('/tmp/some-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.PREINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define preInstall string commands after preInstallFile"() {
+        given:
+        extension.preInstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.preInstall('echo "Done Installing..."')
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.PREINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define preInstall file commands after preInstallFile"() {
+        given:
+        extension.preInstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.preInstall(new File('/tmp/some-other-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.PREINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define postInstallFile more than once"() {
+        given:
+        extension.postInstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.postInstallFile(new File('/tmp/some-other-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.MULTIPLE_POSTINSTALL_FILES
+    }
+
+    def "Cannot define postInstallFile after postInstall string commands"() {
+        given:
+        extension.postInstall('echo "Done Installing..."')
+
+        when:
+        extension.postInstallFile(new File('/tmp/some-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.POSTINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define postInstallFile after postInstall file commands"() {
+        given:
+        extension.postInstall(new File('/tmp/some-other-file'))
+
+        when:
+        extension.postInstallFile(new File('/tmp/some-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.POSTINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define postInstall string commands after postInstallFile"() {
+        given:
+        extension.postInstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.postInstall('echo "Done Installing..."')
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.POSTINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define postInstall file commands after postInstallFile"() {
+        given:
+        extension.postInstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.postInstall(new File('/tmp/some-other-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.POSTINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define preUninstallFile more than once"() {
+        given:
+        extension.preUninstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.preUninstallFile(new File('/tmp/some-other-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.MULTIPLE_PREUNINSTALL_FILES
+    }
+
+    def "Cannot define preUninstallFile after preUninstall string commands"() {
+        given:
+        extension.preUninstall('echo "Done Uninstalling..."')
+
+        when:
+        extension.preUninstallFile(new File('/tmp/some-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.PREUNINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define preUninstallFile after preUninstall file commands"() {
+        given:
+        extension.preUninstall(new File('/tmp/some-other-file'))
+
+        when:
+        extension.preUninstallFile(new File('/tmp/some-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.PREUNINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define preUninstall string commands after preUninstallFile"() {
+        given:
+        extension.preUninstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.preUninstall('echo "Starting Uninstalling..."')
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.PREUNINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define preUninstall file commands after preUninstallFile"() {
+        given:
+        extension.preUninstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.preUninstall(new File('/tmp/some-other-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.PREUNINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define postUninstallFile more than once"() {
+        given:
+        extension.postUninstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.postUninstallFile(new File('/tmp/some-other-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.MULTIPLE_POSTUNINSTALL_FILES
+    }
+
+    def "Cannot define postUninstallFile after postUninstall string commands"() {
+        given:
+        extension.postUninstall('echo "Done Uninstalling..."')
+
+        when:
+        extension.postUninstallFile(new File('/tmp/some-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.POSTUNINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define postUninstallFile after postUninstall file commands"() {
+        given:
+        extension.postUninstall(new File('/tmp/some-other-file'))
+
+        when:
+        extension.postUninstallFile(new File('/tmp/some-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.POSTUNINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define postUninstall string commands after postUninstallFile"() {
+        given:
+        extension.postUninstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.postUninstall('echo "Done Installing..."')
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.POSTUNINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
+
+    def "Cannot define postUninstall file commands after postUninstallFile"() {
+        given:
+        extension.postUninstallFile(new File('/tmp/some-file'))
+
+        when:
+        extension.postUninstall(new File('/tmp/some-other-file'))
+
+        then:
+        Throwable t = thrown(IllegalStateException)
+        t == SystemPackagingExtension.POSTUNINSTALL_COMMANDS_AND_FILE_DEFINED
+    }
 }


### PR DESCRIPTION
This PR defines four new properties that allow defining the complete maintainer script files.

* `preInstallFile`
* `postInstallFile`
* `preUninstallFile`
* `postUninstallFile`

These directives are only supported when building a deb and allow scripts to be written with shebang lines other than `#!/bin/sh`:

```py
#!/usr/bin/env python3

print("Starting to install...")
```

An `IllegalStateException` is thrown when multiple of the same file is defined, or commands and the file are defined at the same time. For example:

```console
* Where:
Build file '/Projects/sample-package/build.gradle' line: 26

* What went wrong:
A problem occurred evaluating root project 'sample-package'.
> Cannot specify PreInstall File and PreInstall Commands
```


Attempting to use the new directives in a custom `Rpm` task will yield the following warning:

```console
At least one of (preInstallFile|postInstallFile|preUninstallFile|postUninstallFile) is defined and will be ignored for RPM builds
```

This PR is related to issues #84, #119, #138.