### PR TITLE
Add Input and Optional to Maintainer Scripts

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -158,9 +158,13 @@ class SystemPackagingExtension {
 
     // Scripts
 
+    @Input @Optional
     File preInstallFile
+    @Input @Optional
     File postInstallFile
+    @Input @Optional
     File preUninstallFile
+    @Input @Optional
     File postUninstallFile
 
     final List<Object> configurationFiles = []


### PR DESCRIPTION
Add the Input and Optional annotations to the new maintainer scripts declarations to better utilize gradle's UP-TO-DATE checks.