### PR TITLE
Do not create empty maintainer scripts for deb-package

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGenerator.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGenerator.groovy
@@ -34,7 +34,7 @@ class MaintainerScriptsGenerator {
         for (script in scripts) {
             if(script.file) {
                 fileSystem.copy(script.file, new File(destination, script.name))
-            } else {
+            } else if (script.commands) {
                 templateHelper.generateFile(script.name, context + [commands: installUtils + script.commands.collect { stripShebang(it) }])
             }
         }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -125,22 +125,22 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
 
     @Input @Optional
     List<Object> getAllPreInstallCommands() {
-        return getPreInstallCommands() + parentExten?.getPreInstallCommands()
+        return getPreInstallCommands() + (parentExten?.getPreInstallCommands() ?: [])
     }
 
     @Input @Optional
     List<Object> getAllPostInstallCommands() {
-        return getPostInstallCommands() + parentExten?.getPostInstallCommands()
+        return getPostInstallCommands() + (parentExten?.getPostInstallCommands() ?: [])
     }
 
     @Input @Optional
     List<Object> getAllPreUninstallCommands() {
-        return getPreUninstallCommands() + parentExten?.getPreUninstallCommands()
+        return getPreUninstallCommands() + (parentExten?.getPreUninstallCommands() ?: [])
     }
 
     @Input @Optional
     List<Object> getAllPostUninstallCommands() {
-        return getPostUninstallCommands() + parentExten?.getPostUninstallCommands()
+        return getPostUninstallCommands() + (parentExten?.getPostUninstallCommands() ?: [])
     }
 
     @Input @Optional

--- a/src/test/groovy/com/netflix/gradle/plugins/application/OspackageApplicationPluginLauncherSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/application/OspackageApplicationPluginLauncherSpec.groovy
@@ -39,9 +39,7 @@ class OspackageApplicationPluginLauncherSpec extends IntegrationSpec {
             scan.getEntry(".${it}").isFile()
         }
 
-        scan.controlContents.containsKey('./postinst')
-        scan.controlContents['./postinst'] =~ /configure\)\s+;;/ // No commands
-
+        !scan.controlContents.containsKey('./postinst')
     }
 
     def 'can customize destination'() {

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGeneratorSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGeneratorSpec.groovy
@@ -32,7 +32,7 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
         0 * templateHelper.generateFile('preinst', _ as Map<String, Object>)
     }
 
-    def 'call templateHelper when no preInstallFile defined'() {
+    def 'do not generate preinst when no preInstall and preInstallFile defined'() {
         given:
         Deb task = project.task([type: Deb], 'buildDeb', {
             preInstallFile = null
@@ -44,7 +44,7 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
 
         then:
         0 * fileSystemActions.copy(_ as File, _ as File)
-        1 * templateHelper.generateFile('preinst', _ as Map<String, Object>)
+        0 * templateHelper.generateFile('preinst', _ as Map<String, Object>)
     }
 
     def 'does not call templateHelper if postInstallFile defined'() {
@@ -64,7 +64,7 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
         0 * templateHelper.generateFile('postinst', _ as Map<String, Object>)
     }
 
-    def 'call templateHelper when no postInstallFile defined'() {
+    def 'do not generate postinst when when no postInstall and postInstallFile defined'() {
         given:
         Deb task = project.task([type: Deb], 'buildDeb', {
             postInstallFile = null
@@ -76,7 +76,7 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
 
         then:
         0 * fileSystemActions.copy(_ as File, _ as File)
-        1 * templateHelper.generateFile('postinst', _ as Map<String, Object>)
+        0 * templateHelper.generateFile('postinst', _ as Map<String, Object>)
     }
 
     def 'does not call templateHelper if preUninstallFile defined'() {
@@ -96,7 +96,7 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
         0 * templateHelper.generateFile('prerm', _ as Map<String, Object>)
     }
 
-    def 'call templateHelper when no preUninstallFile defined'() {
+    def 'do not generate prerm when no preUninstall and preUninstallFile defined'() {
         given:
         Deb task = project.task([type: Deb], 'buildDeb', {
             preUninstallFile = null
@@ -108,7 +108,7 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
 
         then:
         0 * fileSystemActions.copy(_ as File, _ as File)
-        1 * templateHelper.generateFile('prerm', _ as Map<String, Object>)
+        0 * templateHelper.generateFile('prerm', _ as Map<String, Object>)
     }
 
     def 'does not call templateHelper if postUninstallFile defined'() {
@@ -128,7 +128,7 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
         0 * templateHelper.generateFile('postrm', _ as Map<String, Object>)
     }
 
-    def 'call templateHelper when no postUninstallFile defined'() {
+    def 'do not generate postrm when no postUninstall and postUninstallFile defined'() {
         given:
         Deb task = project.task([type: Deb], 'buildDeb', {
             postUninstallFile = null
@@ -140,6 +140,6 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
 
         then:
         0 * fileSystemActions.copy(_ as File, _ as File)
-        1 * templateHelper.generateFile('postrm', _ as Map<String, Object>)
+        0 * templateHelper.generateFile('postrm', _ as Map<String, Object>)
     }
 }


### PR DESCRIPTION
When neither script command and script file is not defined.
Fixing 'maintainer-script-empty' warning from lintian.
