### PR TITLE
Add changelogFile member to Rpm, and use redline-1.2.4 for support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ contacts {
 
 dependencies {
     compile 'org.apache.commons:commons-lang3:3.1'
-    compile('org.redline-rpm:redline:1.2.2') {
+    compile('org.redline-rpm:redline:1.2.3') {
         // Where logging goes is a runtime decision
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ contacts {
 
 dependencies {
     compile 'org.apache.commons:commons-lang3:3.1'
-    compile('org.redline-rpm:redline:1.2.3') {
+    compile('org.redline-rpm:redline:1.2.4') {
         // Where logging goes is a runtime decision
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
@@ -19,6 +19,7 @@ package com.netflix.gradle.plugins.rpm
 import com.netflix.gradle.plugins.packaging.AbstractPackagingCopyAction
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Optional
 import org.redline_rpm.header.Architecture
 import org.redline_rpm.header.Os
@@ -27,6 +28,8 @@ import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
 
 class Rpm extends SystemPackagingTask {
+	@InputFile @Optional
+	File changeLogFile
     Rpm() {
         super()
         extension = 'rpm'
@@ -75,4 +78,12 @@ class Rpm extends SystemPackagingTask {
     List<String> getPrefixes() {
         exten.prefixes
     }
+
+	public File getChangeLogFile() {
+		return changeLogFile;
+	}
+
+	public void setChangeLogFile(File changeLogFile) {
+		this.changeLogFile = changeLogFile;
+	}
 }

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -96,6 +96,9 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
         builder.setPreTransScript(scriptWithUtils(task.allCommonCommands, task.allPreTransCommands))
         builder.setPostTransScript(scriptWithUtils(task.allCommonCommands, task.allPostTransCommands))
 
+		if (((Rpm) task).changeLogFile != null){
+			builder.addChangelogFile(((Rpm) task).changeLogFile)
+		}
 
         rpmFileVisitorStrategy = new RpmFileVisitorStrategy(builder)
     }


### PR DESCRIPTION
This is an implementation to resolve issue https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/164 .  It makes use of the new Builder.addChangeLog() method in redline-1.2.3.
