### PR TITLE
Add Mappings for ospackage Block File Directives

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -92,6 +92,11 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
         mapping.map('createDirectoryEntry', { parentExten?.getCreateDirectoryEntry()?:false })
         mapping.map('priority', { parentExten?.getPriority()?:'optional' })
 
+        mapping.map('preInstallFile', { parentExten?.getPreInstallFile() })
+        mapping.map('postInstallFile', { parentExten?.getPostInstallFile() })
+        mapping.map('preUninstallFile', { parentExten?.getPreUninstallFile() })
+        mapping.map('postUninstallFile', { parentExten?.getPostUninstallFile() })
+
         // Task Specific
         mapping.map('archiveName', { assembleArchiveName() })
     }


### PR DESCRIPTION
Currently the file directives for maintainer scripts must be defined on `buildDeb`. 

This change allows them to be defined on `ospackage`:

```gradle
ospackage {
    preInstallFile file('scripts/preinstall.sh')
}
```