### PR TITLE
Fix directory permissions to be set using dirMode instead of fileMode field (in RpmCopyAction.groovy)

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -134,7 +134,7 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
 
         if (createDirectoryEntry) {
             logger.debug 'adding directory {}', dirDetails.relativePath.pathString
-            int dirMode = lookup(specToLookAt, 'fileMode') ?: dirDetails.mode
+            int dirMode = lookup(specToLookAt, 'dirMode') ?: dirDetails.mode
             Directive directive = (Directive) lookup(specToLookAt, 'fileType') ?: task.fileType
             String user = lookup(specToLookAt, 'user') ?: task.user
             String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup


### PR DESCRIPTION
There is bug - directory permissions must be set using dirMode instead of fileMode field.
Fix line
int dirMode = lookup(specToLookAt, 'fileMode') ?: dirDetails.mode
Change to
int dirMode = lookup(specToLookAt, 'dirMode') ?: dirDetails.mode