### PR TITLE
Mark MaintainerScripts with InputFile

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -158,13 +158,13 @@ class SystemPackagingExtension {
 
     // Scripts
 
-    @Input @Optional
+    @InputFile @Optional
     File preInstallFile
-    @Input @Optional
+    @InputFile @Optional
     File postInstallFile
-    @Input @Optional
+    @InputFile @Optional
     File preUninstallFile
-    @Input @Optional
+    @InputFile @Optional
     File postUninstallFile
 
     final List<Object> configurationFiles = []


### PR DESCRIPTION
This change allows gradle to track content changes of the files in addition to path changes of the property. Fixes #217 