### PR TITLE
Fixed issue with addParentDirs and createDirectoryEntry properties

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -115,7 +115,7 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
 
         int fileMode = lookup(specToLookAt, 'fileMode') ?: fileDetails.mode
         def specAddParentsDir = lookup(specToLookAt, 'addParentDirs')
-        boolean addParentsDir = specAddParentsDir ?: task.addParentDirs
+        boolean addParentsDir = specAddParentsDir!=null ? specAddParentsDir : task.addParentDirs
 
         rpmFileVisitorStrategy.addFile(fileDetails, inputFile, fileMode, -1, fileType, user, group, addParentsDir)
     }
@@ -128,9 +128,9 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
         }
         // Have to take booleans specially, since they would fail an elvis operator if set to false
         def specCreateDirectoryEntry = lookup(specToLookAt, 'createDirectoryEntry')
-        boolean createDirectoryEntry = specCreateDirectoryEntry ?: task.createDirectoryEntry
+        boolean createDirectoryEntry = specCreateDirectoryEntry!=null ? specCreateDirectoryEntry : task.createDirectoryEntry
         def specAddParentsDir = lookup(specToLookAt, 'addParentDirs')
-        boolean addParentsDir = specAddParentsDir ?: task.addParentDirs
+        boolean addParentsDir = specAddParentsDir!=null ? specAddParentsDir : task.addParentDirs
 
         if (createDirectoryEntry) {
             logger.debug 'adding directory {}', dirDetails.relativePath.pathString

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -107,6 +107,11 @@ class RpmPluginTest extends ProjectSpec {
                 path.startsWith(fileName)
             }
         }
+        scan.files*.name.every { fileName ->
+            ['./a/path/not/to/create'].every { path ->
+                ! path.startsWith(fileName)
+            }
+        }
     }
 
     def 'obsoletesAndConflicts'() {


### PR DESCRIPTION
Fixed issue with addParentDirs and createDirectoryEntry properties not being handled properly.

Also added test to catch future regression. Fixes issues #124 and #212 and #197.