### PR TITLE
Support Directory Installation with Custom Groups

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -62,6 +62,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
     private final DebTaskPropertiesValidator debTaskPropertiesValidator = new DebTaskPropertiesValidator()
     private DebFileVisitorStrategy debFileVisitorStrategy
     private final MaintainerScriptsGenerator maintainerScriptsGenerator
+    private final InstallLineGenerator installLineGenerator
 
     DebCopyAction(Deb debTask) {
         super(debTask)
@@ -80,6 +81,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         debianDir = new File(task.project.buildDir, "debian")
         debFileVisitorStrategy = new DebFileVisitorStrategy(dataProducers, installDirs)
         maintainerScriptsGenerator = new MaintainerScriptsGenerator(debTask, new TemplateHelper(debianDir, '/deb'), debianDir, new ApacheCommonsFileSystemActions())
+        installLineGenerator = new InstallLineGenerator()
     }
 
     @Canonical
@@ -325,17 +327,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
                 customFields: getCustomFields(),
 
                 // Uses install command for directory
-                dirs: installDirs.collect { InstallDir dir ->
-                    def map = [name: dir.name]
-                    if(dir.user) {
-                        if (dir.group) {
-                            map['owner'] = "${dir.user}:${dir.group}"
-                        } else {
-                            map['owner'] = dir.user
-                        }
-                    }
-                    return map
-                }
+                dirs: installDirs.collect { InstallDir dir -> [install: installLineGenerator.generate(dir)] }
         ]
     }
 

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/InstallLineGenerator.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/InstallLineGenerator.groovy
@@ -1,0 +1,15 @@
+package com.netflix.gradle.plugins.deb
+
+class InstallLineGenerator {
+    String generate(DebCopyAction.InstallDir dir) {
+        StringBuilder sb = new StringBuilder("install ")
+        if(dir.user) {
+            sb.append("-o ${dir.user} ")
+        }
+        if(dir.group) {
+            sb.append("-g ${dir.group} ")
+        }
+        sb.append("-d ${dir.name}")
+        sb.toString()
+    }
+}

--- a/src/main/resources/deb/postinst.ftl
+++ b/src/main/resources/deb/postinst.ftl
@@ -8,11 +8,7 @@ ec() {
 case "\$1" in
     configure)
         <% dirs.each{ dir -> %>
-        <% if (dir['owner']) { %>
-            ec install -o <%= dir['owner'] %> -d <%= dir['name'] %>
-        <% } else { %>
-            ec install -d <%= dir['name'] %>
-        <% } %>
+            ec <%= dir['install'] %>
         <% } %>
 
         <% commands.each {command -> %>

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/InstallLineGeneratorSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/InstallLineGeneratorSpec.groovy
@@ -1,0 +1,24 @@
+package com.netflix.gradle.plugins.deb
+
+import com.netflix.gradle.plugins.deb.DebCopyAction.InstallDir
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class InstallLineGeneratorSpec extends Specification {
+
+    @Unroll
+    def 'should generate correct install line for #dir.name'(InstallDir dir, String line) {
+        given:
+        def generator = new InstallLineGenerator()
+
+        expect:
+        generator.generate(dir) == line
+
+        where:
+        dir                                                            | line
+        new InstallDir('dir-with-default-user-and-group')              | 'install -d dir-with-default-user-and-group'
+        new InstallDir('dir-with-user-only', 'user-b')                 | 'install -o user-b -d dir-with-user-only'
+        new InstallDir('dir-with-user-and-group', 'user-c', 'group-c') | 'install -o user-c -g group-c -d dir-with-user-and-group'
+        new InstallDir('dir-with-group-only', null, 'group-d')         | 'install -g group-d -d dir-with-group-only'
+    }
+}

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/TemplateHelperSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/TemplateHelperSpec.groovy
@@ -33,7 +33,8 @@ class TemplateHelperSpec extends Specification {
         url: 'URL',
         depends: '',
         arch: 'Arch',
-        dirs: 'dirs',
+        dirs: [],
+        commands: [],
         multiArch: '',
         conflicts: '',
         recommends: '',
@@ -64,5 +65,18 @@ class TemplateHelperSpec extends Specification {
         resultFile.exists()
         resultFile.text.contains('Depends: Depends1')
         resultFile.text.contains('Multi-Arch: MultiArch1')
+    }
+
+    def 'produces install line for directories'() {
+        given:
+        def context = defaultContext + [dirs: [
+                [install: 'install -d no-user-or-group-specified']
+        ]]
+
+        when:
+        def resultFile = helper.generateFile('postinst', context)
+
+        then:
+        resultFile.text.contains('ec install -d no-user-or-group-specified')
     }
 }


### PR DESCRIPTION
To facilitate easier testing, move the conditional install-line builder logic from postinst.ftl to its own class. 

Support installing directories with custom groups as per the [install docs](https://www.gnu.org/software/coreutils/manual/html_node/install-invocation.html) and #80.