### PR TITLE
Declare Deb .changes File as OutputFile

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
 
 class Deb extends SystemPackagingTask {
     Deb() {
@@ -97,5 +98,10 @@ class Deb extends SystemPackagingTask {
     @Input @Optional
     Map<String, String> getAllCustomFields() {
         return getCustomFields() + (parentExten?.getCustomFields() ?: [:])
+    }
+
+    @OutputFile
+    File getChangesFile() {
+        return new File(getArchivePath().path.replaceFirst('deb$', 'changes'))
     }
 }

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -258,8 +258,6 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
             maker.setSignPackage(true)
         }
 
-        logger.info("Creating debian package: ${debFile}")
-
         try {
             logger.info("Creating debian package: ${debFile}")
             maker.setCompression(Compression.GZIP.toString())
@@ -267,10 +265,6 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         } catch (Exception e) {
             throw new GradleException("Can't build debian package ${debFile}", e)
         }
-
-        // TODO Put changes file into a separate task
-        //def changesFile = new File("${packagePath}_all.changes")
-        //createChanges(pkg, changesFile, descriptor, processor)
 
         logger.info 'Created deb {}', debFile
     }

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -50,6 +50,21 @@ class DebPluginTest extends ProjectSpec {
         debFile.exists()
     }
 
+    def 'outputs declared'() {
+        when:
+        project.apply plugin: 'nebula.deb'
+
+        Deb debTask = project.task([type: Deb], 'buildDeb', {
+            packageName 'testpkg'
+            version '1.0.0'
+            release '1'
+        })
+
+        then:
+        Set<String> declaredOutputs = debTask.outputs.files.collect { it.name }
+        ['testpkg_1.0.0-1_all.deb', 'testpkg_1.0.0-1_all.changes'].toSet() == declaredOutputs
+    }
+
 //    public void alwaysRun(DefaultTask task ) {
 //        assertTrue(this instanceof GroovyObject)
 //        assertTrue(task.inputs instanceof GroovyObject)


### PR DESCRIPTION
* Uses archivePath to get name of debian, and declares corresponding changes file as task output
* Removes stale TODO
* Removes redundant log statement
* Closes #114 