### PR TITLE
Support symlinks by default

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/ProjectPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/ProjectPackagingExtension.groovy
@@ -1,8 +1,15 @@
 package com.netflix.gradle.plugins.packaging
 
+import com.netflix.gradle.plugins.utils.FromConfigurationFactory
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.file.*
+import org.gradle.api.file.CopyProcessingSpec
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.file.FileCopyDetails
+import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.internal.file.copy.DefaultCopySpec
@@ -37,9 +44,18 @@ public class ProjectPackagingExtension extends SystemPackagingExtension {
      * Special Use cases that involve Closure's which we want to wrap:
      */
     CopySpec from(Object sourcePath, Closure c) {
+        def preserveSymlinks = FromConfigurationFactory.preserveSymlinks(this)
         use(CopySpecEnhancement) {
-            return getDelegateCopySpec().from(sourcePath, c);
+            return getDelegateCopySpec().from(sourcePath, c << preserveSymlinks)
         }
+    }
+
+    CopySpec from(Object... sourcePaths) {
+        def spec = null
+        for (Object sourcePath : sourcePaths) {
+            spec = from(sourcePath, {})
+        }
+        return spec
     }
 
     CopySpec into(Object destPath, Closure configureClosure) {
@@ -132,10 +148,6 @@ public class ProjectPackagingExtension extends SystemPackagingExtension {
 
     public CopySpec with(CopySpec... sourceSpecs) {
         return getDelegateCopySpec().with(sourceSpecs);
-    }
-
-    public CopySourceSpec from(Object... sourcePaths) {
-        return getDelegateCopySpec().from(sourcePaths);
     }
 
 //    public CopySpec from(Object sourcePath, Closure c) {

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -16,10 +16,17 @@
 
 package com.netflix.gradle.plugins.packaging
 
+import com.netflix.gradle.plugins.utils.FromConfigurationFactory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.AbstractCopyTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.redline_rpm.header.Architecture
 
@@ -233,9 +240,18 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
     }
 
     @Override
+    AbstractCopyTask from(Object... sourcePaths) {
+        for (Object sourcePath : sourcePaths) {
+            from(sourcePath, {})
+        }
+        return this
+    }
+
+    @Override
     public AbstractCopyTask from(Object sourcePath, Closure c) {
+        def preserveSymlinks = FromConfigurationFactory.preserveSymlinks(this)
         use(CopySpecEnhancement) {
-            getMainSpec().from(sourcePath, c);
+            getMainSpec().from(sourcePath, c << preserveSymlinks)
         }
         return this
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/utils/FromConfigurationFactory.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/utils/FromConfigurationFactory.groovy
@@ -1,0 +1,22 @@
+package com.netflix.gradle.plugins.utils
+
+import org.gradle.api.file.FileCopyDetails
+import org.gradle.api.tasks.AbstractCopyTask
+
+import java.nio.file.Files
+
+class FromConfigurationFactory {
+
+    static Closure<AbstractCopyTask> preserveSymlinks(delegate) {
+        return {
+            delegate.eachFile { FileCopyDetails details ->
+                if (Files.isSymbolicLink(details.file.toPath())) {
+                    details.exclude()
+                    def toFile = Files.readSymbolicLink(details.file.toPath()).toFile()
+                    delegate.link(details.relativePath.toString(), toFile.toString())
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/groovy/com/netflix/gradle/plugins/utils/JavaNIOUtils.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/utils/JavaNIOUtils.groovy
@@ -25,4 +25,8 @@ final class JavaNIOUtils {
         Path targetDir = createPath(target.path)
         Files.createSymbolicLink(newLink, targetDir)
     }
+
+    static Path createTempFile(String prefix, String suffix) {
+        return Files.createTempFile(prefix, suffix)
+    }
 }

--- a/src/main/groovy/com/netflix/gradle/plugins/utils/JavaNIOUtils.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/utils/JavaNIOUtils.groovy
@@ -20,7 +20,7 @@ final class JavaNIOUtils {
         Files.readSymbolicLink(path)
     }
 
-    static void createSymblicLink(File source, File target) {
+    static void createSymbolicLink(File source, File target) {
         Path newLink = createPath(source.path)
         Path targetDir = createPath(target.path)
         Files.createSymbolicLink(newLink, targetDir)

--- a/src/test/groovy/com/netflix/gradle/plugins/docker/OsPackageDockerPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/docker/OsPackageDockerPluginTest.groovy
@@ -2,8 +2,6 @@ package com.netflix.gradle.plugins.docker
 
 import nebula.test.ProjectSpec
 import org.apache.commons.io.FileUtils
-import org.gradle.api.Project
-import org.gradle.testfixtures.ProjectBuilder
 
 class OsPackageDockerPluginTest extends ProjectSpec {
 

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -996,7 +996,7 @@ class RpmPluginTest extends ProjectSpec {
         File fooDir = new File(binDir, 'foo-1.2')
         binDir.mkdirs()
         FileUtils.writeStringToFile(new File(fooDir, 'foo.txt'), 'foo')
-        JavaNIOUtils.createSymblicLink(new File(binDir, 'foo'), fooDir)
+        JavaNIOUtils.createSymbolicLink(new File(binDir, 'foo'), fooDir)
 
         when:
         project.apply plugin: 'nebula.rpm'
@@ -1287,7 +1287,7 @@ class RpmPluginTest extends ProjectSpec {
         Path target = JavaNIOUtils.createTempFile("file-to-symlink-to", "sh")
         File file = project.file('bin/my-symlink')
         Files.createParentDirs(file)
-        JavaNIOUtils.createSymblicLink(file, target.toFile())
+        JavaNIOUtils.createSymbolicLink(file, target.toFile())
 
         when:
         project.apply plugin: 'nebula.rpm'


### PR DESCRIPTION
Closes #58 by supporting symlinks by default in the `from` block.

Notes:
* follows the convention of `ProjectPackagingExtension` of commenting out an overridden method
* `from` directives that do not have closures are redirected to `from` directives with a symlink-preserving closure
* `from` directives with closures are composed with the symlink-preserving closure
* symlink-preserving closure heavily inspired by workarounds proposed in #58.
* Possible issue (that also exists with the workarounds in #58): by default, symlinks are created as owned by `root/root`, whereas the default for other files is `$USER/0`
