### PR TITLE
#231 Preferentially use supplied user and permissionGroup in director…

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -185,9 +185,11 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
 
     @Override
     protected void addDirectory(Directory directory) {
+        def user = directory.user ? directory.user : task.user
+        def permissionGroup = directory.permissionGroup ? directory.permissionGroup : task.permissionGroup
         dataProducers << new DataProducerPathTemplate(
             [directory.path] as String[], null, null, 
-            [ new PermMapper(-1, -1, task.user, task.permissionGroup, 
+            [ new PermMapper(-1, -1, user, permissionGroup,
             directory.permissions, -1, 0, null) ] as Mapper[])
     }
 

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -1090,6 +1090,26 @@ class DebPluginTest extends ProjectSpec {
         emptydir.mode == 0750
     }
 
+    @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/231")
+    def 'directory construct with owner and group'() {
+        given:
+        project.apply plugin: 'nebula.deb'
+        Deb debTask = project.task('buildDeb', type: Deb) {
+            user 'test'
+            permissionGroup 'testgroup'
+            directory("/var/log/customemptyfolder", 0750, 'myuser', 'mygroup')
+        }
+
+        when:
+        debTask.execute()
+
+        then:
+        def scan = new Scanner(debTask.archivePath)
+        def emptydir = scan.getEntry('./var/log/customemptyfolder/')
+        emptydir.userName == 'myuser'
+        emptydir.groupName == 'mygroup'
+    }
+
     @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/161")
     def 'equal task dependencies are equal'() {
         expect:


### PR DESCRIPTION
Fixes #231.

Preferentially use supplied user and permissionGroup in directory() construct for deb packages. This brings deb behaviour closer to that of rpm.

The `Directory.addParents` flag is still not honoured for deb when set to false. I'm not familiar with jdeb but the creation of parent directories is done deep within jdeb and does not appear to be customisable, unless there is another way to implement addDirectory.
