### PR TITLE
Upgrade redline to allow ~ in version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ contacts {
 
 dependencies {
     compile 'org.apache.commons:commons-lang3:3.1'
-    compile('org.redline-rpm:redline:1.2.4') {
+    compile('org.redline-rpm:redline:1.2.5') {
         // Where logging goes is a runtime decision
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -31,7 +31,6 @@ import org.gradle.api.plugins.BasePlugin
 import org.gradle.testfixtures.ProjectBuilder
 import org.redline_rpm.header.Header
 import org.redline_rpm.header.Signature
-import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -1197,7 +1196,6 @@ class RpmPluginTest extends ProjectSpec {
         ['me', 'defaultUser', 'defaultUser'] == header.getEntry(FILEUSERNAME).values.toList()
     }
 
-    @Ignore
     @Unroll
     def 'handle semantic versions with dashes and metadata (+) expect #version to be #expected'() {
         given:
@@ -1213,7 +1211,7 @@ class RpmPluginTest extends ProjectSpec {
         project.tasks.buildRpm.execute()
 
         expect:
-        project.file("build/tmp/RpmPluginTest/semvertest_${expected}.noarch.rpm").exists()
+        project.file("build/tmp/RpmPluginTest/semvertest-${expected}.noarch.rpm").exists()
 
         where:
         version              | expected


### PR DESCRIPTION
The [new release](https://github.com/craigwblake/redline/releases/tag/redline-1.2.5) of redline allows `~` in versions, which will let rpm and nebula-release-plugin users build without workarounds. 🎉 

Closes #213, also mentioned on #49.