### PR TITLE
Run postinst script template generation when dirs present

### DIFF
--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -67,6 +67,32 @@ class DebPluginTest extends ProjectSpec {
         ['testpkg_1.0.0-1_all.deb', 'testpkg_1.0.0-1_all.changes'].toSet() == declaredOutputs
     }
 
+    def 'createDirectoryEntry generates postinst install line'() {
+        given:
+        String testDir = "${project.buildDir.path}/testdir"
+        File srcDir = new File(testDir, 'a')
+        srcDir.mkdirs()
+        project.apply plugin: 'nebula.deb'
+
+        Deb debTask = project.task([type: Deb], 'buildDeb', {
+            packageName 'postinsttestdeb'
+            permissionGroup 'anothergroup'
+            from(testDir) {
+                into 'subdir'
+                createDirectoryEntry true
+            }
+        })
+
+        when:
+        debTask.execute()
+
+        then:
+        def scan = new Scanner(debTask.getArchivePath())
+        def postinst = scan.controlContents['./postinst']
+        postinst.contains("ec install")
+        postinst.contains("/subdir/a")
+    }
+
 //    public void alwaysRun(DefaultTask task ) {
 //        assertTrue(this instanceof GroovyObject)
 //        assertTrue(task.inputs instanceof GroovyObject)

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGeneratorSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/MaintainerScriptsGeneratorSpec.groovy
@@ -64,7 +64,7 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
         0 * templateHelper.generateFile('postinst', _ as Map<String, Object>)
     }
 
-    def 'do not generate postinst when when no postInstall and postInstallFile defined'() {
+    def 'do not generate postinst when no postInstall, postInstallFile, or dirs defined'() {
         given:
         Deb task = project.task([type: Deb], 'buildDeb', {
             postInstallFile = null
@@ -77,6 +77,22 @@ class MaintainerScriptsGeneratorSpec extends ProjectSpec {
         then:
         0 * fileSystemActions.copy(_ as File, _ as File)
         0 * templateHelper.generateFile('postinst', _ as Map<String, Object>)
+    }
+
+    def 'generate postinst when no postInstall or postInstallFile but dirs defined'() {
+        given:
+        Deb task = project.task([type: Deb], 'buildDeb', {
+            postInstallFile = null
+        }) as Deb
+        context['dirs'] = ['install abc...']
+        def generator = new MaintainerScriptsGenerator(task, templateHelper, new File('/tmp'), fileSystemActions)
+
+        when:
+        generator.generate(context)
+
+        then:
+        0 * fileSystemActions.copy(_ as File, _ as File)
+        1 * templateHelper.generateFile('postinst', _ as Map<String, Object>)
     }
 
     def 'does not call templateHelper if preUninstallFile defined'() {


### PR DESCRIPTION
A regression was introduced for a previously untested feature in v4.3.0.

#203 no longer runs template generation if there are no commands, which works very well for preinst, prerm and postrm. The postinst template also has behavior for 'dirs' implemented, which would not run in v4.3.0 unless the user had also defined postInst commands.

This applies to debians only and includes a test to catch future regressions.