### PR TITLE
Avoid scriptlet generation; special-case %pretrans.

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -89,12 +89,28 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
         }
         builder.addHeaderEntry HeaderTag.SOURCERPM, sourcePackage
 
-        builder.setPreInstallScript(scriptWithUtils(task.allCommonCommands, task.allPreInstallCommands))
-        builder.setPostInstallScript(scriptWithUtils(task.allCommonCommands, task.allPostInstallCommands))
-        builder.setPreUninstallScript(scriptWithUtils(task.allCommonCommands, task.allPreUninstallCommands))
-        builder.setPostUninstallScript(scriptWithUtils(task.allCommonCommands, task.allPostUninstallCommands))
-        builder.setPreTransScript(scriptWithUtils(task.allCommonCommands, task.allPreTransCommands))
-        builder.setPostTransScript(scriptWithUtils(task.allCommonCommands, task.allPostTransCommands))
+        if (!task.allPreInstallCommands?.empty) {
+            builder.setPreInstallScript(scriptWithUtils(task.allCommonCommands, task.allPreInstallCommands))
+        }
+        if (!task.allPostInstallCommands?.empty) {
+            builder.setPostInstallScript(scriptWithUtils(task.allCommonCommands, task.allPostInstallCommands))
+        }
+        if (!task.allPreUninstallCommands?.empty) {
+            builder.setPreUninstallScript(scriptWithUtils(task.allCommonCommands, task.allPreUninstallCommands))
+        }
+        if (!task.allPostUninstallCommands?.empty) {
+            builder.setPostUninstallScript(scriptWithUtils(task.allCommonCommands, task.allPostUninstallCommands))
+        }
+        if (!task.allPreTransCommands?.empty) {
+            // pretrans* scriptlets are special. They may be run in an
+            // environment where no shell exists. It's recommended that they
+            // be avoided where possible, but where not, written in Lua:
+            // https://fedoraproject.org/wiki/Packaging:Scriptlets#The_.25pretrans_Scriptlet
+            builder.setPreTransScript(concat(task.allPreTransCommands))
+        }
+        if (!task.allPostTransCommands?.empty) {
+            builder.setPostTransScript(scriptWithUtils(task.allCommonCommands, task.allPostTransCommands))
+        }
 
 		if (((Rpm) task).changeLogFile != null){
 			builder.addChangelogFile(((Rpm) task).changeLogFile)


### PR DESCRIPTION
Currently, scriptlets are generated for all stages regardless of whether they do anything. This is best avoided.

Additionally, the `%pretrans` scriptlet is being treated the same as any other type of scriptlet. This is a bad idea, as there are conditions where a shell might not be present to run the `%pretrans` scriptlet. Moreover, it's recommended in the [Fedora Packaging Guidelines](https://fedoraproject.org/wiki/Packaging:Scriptlets#The_.25pretrans_Scriptlet) that if a `%pretrans` scriptlet is required, it _must_ be written in Lua. This means it makes no sense to include the preamble added to the scriptlet by `scriptWithUtils`.