### PR TITLE
Extract LegacyInstallCmd, Add installCmd to Daemon Definition

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/DaemonDefinition.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/DaemonDefinition.groovy
@@ -34,4 +34,5 @@ class DaemonDefinition {
     Boolean autoStart // default true
     Integer startSequence // default 85
     Integer stopSequence // default 15
+    String installCmd
 }

--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/LegacyInstallCmd.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/LegacyInstallCmd.groovy
@@ -1,0 +1,13 @@
+package com.netflix.gradle.plugins.daemon
+
+class LegacyInstallCmd {
+    static String create(Map<String, Object> ctx) {
+        if (ctx.isRedHat) {
+            "/sbin/chkconfig ${ctx.daemonName} on"
+        } else {
+            def startRunLevels = ctx.runLevels.join(' ')
+            def stopRunLevels = ([0, 1, 2, 3, 4, 5, 6] - ctx.runLevels).join(' ')
+            "/usr/sbin/update-rc.d ${ctx.daemonName} start ${ctx.startSequence} ${startRunLevels} . stop ${ctx.stopSequence} ${stopRunLevels} ."
+        }
+    }
+}

--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPlugin.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPlugin.groovy
@@ -118,18 +118,13 @@ class OspackageDaemonPlugin implements Plugin<Project> {
                 }
 
                 task.doFirst {
-                    def startSequence = templateTask.getContext().startSequence
-                    def stopSequence = templateTask.getContext().stopSequence
-                    def runLevels = templateTask.getContext().runLevels
-
                     task.postInstall("[ -x /bin/touch ] && touch=/bin/touch || touch=/usr/bin/touch")
                     task.postInstall("\$touch /service/${daemonName}/down")
+                    def ctx = templateTask.getContext()
 
-                    def installCmd = isRedhat?
-                            "/sbin/chkconfig ${daemonName} on":
-                            "/usr/sbin/update-rc.d ${daemonName} start ${startSequence} ${runLevels.join(' ')} . stop ${stopSequence} ${([0,1,2,3,4,5,6]-runLevels).join(' ')} ."
+                    def installCmd = definition.installCmd ?: LegacyInstallCmd.create(ctx)
 
-                    if (templateTask.getContext().autoStart) {
+                    if (ctx.autoStart) {
                         task.postInstall(installCmd)
                     }
 

--- a/src/test/groovy/com/netflix/gradle/plugins/daemon/DaemonExtensionSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/daemon/DaemonExtensionSpec.groovy
@@ -36,6 +36,7 @@ class DaemonExtensionSpec extends Specification {
             autoStart = false
             startSequence = 85
             stopSequence = 15
+            installCmd = 'exit 2'
         }
 
         then:
@@ -51,5 +52,6 @@ class DaemonExtensionSpec extends Specification {
         !definition.autoStart
         definition.startSequence == 85
         definition.stopSequence == 15
+        definition.installCmd == 'exit 2'
     }
 }

--- a/src/test/groovy/com/netflix/gradle/plugins/daemon/LegacyInstallCmdSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/daemon/LegacyInstallCmdSpec.groovy
@@ -1,0 +1,21 @@
+package com.netflix.gradle.plugins.daemon
+
+import spock.lang.Specification
+
+class LegacyInstallCmdSpec extends Specification {
+    def 'should call chkconfig if redhat'() {
+        when:
+        String actual = LegacyInstallCmd.create(isRedHat: true, daemonName: 'ABC')
+
+        then:
+        actual == "/sbin/chkconfig ABC on"
+    }
+
+    def 'should call update-rc.d if not redhat'() {
+        when:
+        String actual = LegacyInstallCmd.create(isRedHat: false, daemonName: 'ABC', runLevels: [3, 4, 5], startSequence: 20, stopSequence: 21)
+
+        then:
+        actual == "/usr/sbin/update-rc.d ABC start 20 3 4 5 . stop 21 0 1 2 6 ."
+    }
+}

--- a/src/test/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPluginSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPluginSpec.groovy
@@ -82,13 +82,16 @@ class OspackageDaemonPluginSpec extends PluginProjectSpec {
         project.daemon {
             daemonName = 'foobar'
             command = 'exit 0'
+            installCmd = 'abc'
         }
 
         then: 'daemon was added to list'
         !extension.daemons.isEmpty()
 
         then: 'daemon configurate'
-        extension.daemons.iterator().next().daemonName == 'foobar'
+        def daemon = extension.daemons.iterator().next()
+        daemon.daemonName == 'foobar'
+        daemon.installCmd == 'abc'
     }
 
     def 'can call daemons extensions in project'() {


### PR DESCRIPTION
If a user supplies an `installCmd` in the daemon definition, use that in the postInstall script. Otherwise fall back to the existing behavior.