### PR TITLE
Support multiline description in deb control file

### DIFF
--- a/src/main/resources/deb/control.ftl
+++ b/src/main/resources/deb/control.ftl
@@ -21,4 +21,6 @@ Pre-Depends: ${preDepends}<% } %><% if (breaks) { %>
 Breaks: ${breaks}<% } %><% customFields?.each { key, val -> %>
 ${key}: ${val}<% } %>
 Description: ${summary}
- ${description}
+<% description.eachLine { %>\
+ ${it}
+<% } %>

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -874,7 +874,8 @@ class DebPluginTest extends ProjectSpec {
         scan.getSigned()
     }
 
-    @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/104")
+    @Issue(["https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/104",
+            "https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/268"])
     @Unroll
     def "Translates package description '#description' to header entry"() {
         given:
@@ -893,13 +894,15 @@ class DebPluginTest extends ProjectSpec {
         scan.getHeaderEntry('Description') == headerEntry
 
         where:
-        description             | headerEntry
-        'This is a description' | 'translates-package-description\n This is a description'
-        ''                      | 'translates-package-description'
-        null                    | 'translates-package-description'
+        description                        | headerEntry
+        'This is a description'            | 'translates-package-description\n This is a description'
+        ''                                 | 'translates-package-description'
+        'This is a\nmultiline description' | 'translates-package-description\n This is a\n multiline description'
+        null                               | 'translates-package-description'
     }
 
-    @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/104")
+    @Issue(["https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/104",
+            "https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/268"])
     @Unroll
     def "Translates project description '#description' to header entry"() {
         given:
@@ -918,10 +921,11 @@ class DebPluginTest extends ProjectSpec {
         scan.getHeaderEntry('Description') == headerEntry
 
         where:
-        description             | headerEntry
-        'This is a description' | 'translates-package-description\n This is a description'
-        ''                      | 'translates-package-description'
-        null                    | 'translates-package-description'
+        description                        | headerEntry
+        'This is a description'            | 'translates-package-description\n This is a description'
+        ''                                 | 'translates-package-description'
+        'This is a\nmultiline description' | 'translates-package-description\n This is a\n multiline description'
+        null                               | 'translates-package-description'
     }
 
     @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/102")


### PR DESCRIPTION
This addresses issue #268. 

According to [Debian docs](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#control), the long `Description` field of the control file should be indented with spaces.

Before, the plugin would not correctly handle multiline `Description`, and as a result jDeb would complain with a cryptic message.
Now, the plugin supports multiline `Description` by correctly indenting with spaces.
 