### PR TITLE
#285 - Avoid empty preTrans and postTrans scriptlets

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -150,17 +150,17 @@ public abstract class SystemPackagingTask extends AbstractArchiveTask {
 
     @Input @Optional
     List<Object> getAllPreTransCommands() {
-        return getPreTransCommands() + parentExten?.getPreTransCommands()
+        return getPreTransCommands() + (parentExten?.getPreTransCommands() ?: [])
     }
 
     @Input @Optional
     List<Object> getAllPostTransCommands() {
-        return getPostTransCommands() + parentExten?.getPostTransCommands()
+        return getPostTransCommands() + (parentExten?.getPostTransCommands() ?: [])
     }
 
     @Input @Optional
     List<Object> getAllCommonCommands() {
-        return getCommonCommands() + parentExten?.getCommonCommands()
+        return getCommonCommands() + (parentExten?.getCommonCommands() ?: [])
     }
 
     /**


### PR DESCRIPTION
Fixes issue #285
Implementing the same way as it's done for the other scriptlets (where it's working) which were adapted to avoid empty scriptlets in deb packages.