### PR TITLE
Gradle 5.0 Compatibility

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/AbstractPackagingCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/AbstractPackagingCopyAction.groovy
@@ -18,7 +18,6 @@ package com.netflix.gradle.plugins.packaging
 
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
 import org.gradle.api.internal.file.copy.*
-import org.gradle.api.internal.tasks.SimpleWorkResult
 import org.gradle.api.tasks.WorkResult
 import org.gradle.api.tasks.WorkResults
 import org.gradle.internal.UncheckedException
@@ -46,12 +45,7 @@ public abstract class AbstractPackagingCopyAction<T extends SystemPackagingTask>
         } catch (Exception e) {
             UncheckedException.throwAsUncheckedException(e)
         }
-        try {
-            // Gradle 4.2 and later
-            return WorkResults.didWork(true)
-        } catch (NoClassDefFoundError ignored) {
-            return new SimpleWorkResult(true)
-        }
+        return WorkResults.didWork(true)
     }
 
     // Not a static class


### PR DESCRIPTION
Remove fallback call to org.gradle.api.internal.tasks.SimpleWorkResult. This is removed in 5.0 and means this plugin will now work with Gradle 4.2 (Released 2017-09-20) and later. [WorkResults](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/WorkResults.html) was added in 4.2.