### PR TITLE
Update org.redline-rpm:redline to 1.2.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ contacts {
 
 dependencies {
     compile 'org.apache.commons:commons-lang3:3.1'
-    compile('org.redline-rpm:redline:1.2.6') {
+    compile('org.redline-rpm:redline:1.2.7') {
         // Where logging goes is a runtime decision
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -9,8 +9,8 @@
             "requested": "3.1"
         },
         "org.redline-rpm:redline": {
-            "locked": "1.2.6",
-            "requested": "1.2.6"
+            "locked": "1.2.7",
+            "requested": "1.2.7"
         },
         "org.vafer:jdeb": {
             "locked": "1.4",


### PR DESCRIPTION
fix issue #252 
new version contains fix for: 'org.redline_rpm.payload.Directive@ecad12' cannot be serialized.