### PR TITLE
Configurable template folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 bin
 build
 gradle.properties
+.DS_STORE
+**/.DS_STORE
 
 out
 *.ipr

--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/DaemonTemplateTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/DaemonTemplateTask.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.TaskAction
  * Monster class that does everything.
  */
 class DaemonTemplateTask extends ConventionTask {
+
     //@Input
     Map<String, String> context
 
@@ -33,9 +34,12 @@ class DaemonTemplateTask extends ConventionTask {
     @Input
     File destDir
 
+    @Input
+    String templatesFolder
+
     @TaskAction
     def template() {
-        TemplateHelper templateHelper = new TemplateHelper(getDestDir(), '/com/netflix/gradle/plugins/daemon')
+        TemplateHelper templateHelper = new TemplateHelper(getDestDir(), getTemplatesFolder())
         getTemplates().collect { String templateName ->
             templateHelper.generateFile(templateName, getContext())
         }

--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/DaemonTemplatesConfigExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/DaemonTemplatesConfigExtension.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.gradle.plugins.daemon
+
+class DaemonTemplatesConfigExtension {
+    String folder
+}

--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPlugin.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPlugin.groovy
@@ -30,6 +30,9 @@ import org.gradle.api.internal.collections.ListElementSource
 class OspackageDaemonPlugin implements Plugin<Project> {
     Project project
     DaemonExtension extension
+    DaemonTemplatesConfigExtension daemonTemplatesConfigExtension
+
+    private final String DEFAULT_TEMPLATE_PREFIX = '/com/netflix/gradle/plugins/daemon'
 
     Map<String,Object> toContext(DaemonDefinition definitionDefaults, DaemonDefinition definition) {
         return [
@@ -54,6 +57,7 @@ class OspackageDaemonPlugin implements Plugin<Project> {
         def factory = new BackwardsCompatibleDomainObjectCollectionFactory<>(project.gradle.gradleVersion)
         DomainObjectCollection<DaemonDefinition> daemonsList = factory.create(DaemonDefinition)
         extension = project.extensions.create('daemons', DaemonExtension, daemonsList)
+        daemonTemplatesConfigExtension = project.extensions.create('daemonsTemplates', DaemonTemplatesConfigExtension)
 
         // Add daemon to project
         project.ext.daemon = { Closure closure ->
@@ -95,6 +99,7 @@ class OspackageDaemonPlugin implements Plugin<Project> {
 
                 def templateTask = project.tasks.create("${task.name}${cleanedName}Daemon", DaemonTemplateTask)
                 templateTask.conventionMapping.map('destDir') { outputDir }
+                templateTask.conventionMapping.map('templatesFolder') {  daemonTemplatesConfigExtension.folder ?: DEFAULT_TEMPLATE_PREFIX  }
                 templateTask.conventionMapping.map('context') {
                     Map<String, String> context = toContext(defaults, definition)
                     context.daemonName = daemonName

--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPlugin.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPlugin.groovy
@@ -23,16 +23,13 @@ import com.netflix.gradle.plugins.utils.BackwardsCompatibleDomainObjectCollectio
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.internal.DefaultDomainObjectCollection
-import org.gradle.api.internal.collections.ElementSource
-import org.gradle.api.internal.collections.ListElementSource
 
 class OspackageDaemonPlugin implements Plugin<Project> {
     Project project
     DaemonExtension extension
     DaemonTemplatesConfigExtension daemonTemplatesConfigExtension
 
-    private final String DEFAULT_TEMPLATE_PREFIX = '/com/netflix/gradle/plugins/daemon'
+    private final String DEFAULT_TEMPLATES_FOLDER = '/com/netflix/gradle/plugins/daemon'
 
     Map<String,Object> toContext(DaemonDefinition definitionDefaults, DaemonDefinition definition) {
         return [
@@ -99,7 +96,7 @@ class OspackageDaemonPlugin implements Plugin<Project> {
 
                 def templateTask = project.tasks.create("${task.name}${cleanedName}Daemon", DaemonTemplateTask)
                 templateTask.conventionMapping.map('destDir') { outputDir }
-                templateTask.conventionMapping.map('templatesFolder') {  daemonTemplatesConfigExtension.folder ?: DEFAULT_TEMPLATE_PREFIX  }
+                templateTask.conventionMapping.map('templatesFolder') {  daemonTemplatesConfigExtension.folder ?: DEFAULT_TEMPLATES_FOLDER  }
                 templateTask.conventionMapping.map('context') {
                     Map<String, String> context = toContext(defaults, definition)
                     context.daemonName = daemonName

--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/TemplateHelper.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/TemplateHelper.groovy
@@ -26,11 +26,11 @@ class TemplateHelper {
     private final GStringTemplateEngine engine = new GStringTemplateEngine()
 
     File destDir
-    String templatePrefix
+    String templatesFolder
 
-    TemplateHelper(File destDir, String templatePrefix) {
+    TemplateHelper(File destDir, String templatesFolder) {
         this.destDir = destDir
-        this.templatePrefix = templatePrefix
+        this.templatesFolder = templatesFolder
     }
 
     File generateFile(String templateName, Map context) {
@@ -50,10 +50,10 @@ class TemplateHelper {
 
     private InputStream getTemplateContent(String templateName) {
         try {
-            String path = "${templatePrefix}/${templateName}.tpl"
+            String path = "${templatesFolder}/${templateName}.tpl"
             return getClass().getResourceAsStream(path) ?: new File(path).newInputStream()
         } catch(Exception e) {
-            throw new FileNotFoundException("Could not find template $templateName in $templatePrefix")
+            throw new FileNotFoundException("Could not find template $templateName in $templatesFolder")
         }
     }
 

--- a/src/main/groovy/com/netflix/gradle/plugins/daemon/TemplateHelper.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/daemon/TemplateHelper.groovy
@@ -40,12 +40,21 @@ class TemplateHelper {
                 throw new IllegalArgumentException("Context key $key has a null value")
             }
         }
-        def template = getClass().getResourceAsStream("${templatePrefix}/${templateName}.tpl").newReader()
+        def template = getTemplateContent(templateName).newReader()
         def content = engine.createTemplate(template).make(context).toString()
         def contentFile = new File(destDir, templateName)
         destDir.mkdirs()
         contentFile.text = content
         return contentFile
+    }
+
+    private InputStream getTemplateContent(String templateName) {
+        try {
+            String path = "${templatePrefix}/${templateName}.tpl"
+            return getClass().getResourceAsStream(path) ?: new File(path).newInputStream()
+        } catch(Exception e) {
+            throw new FileNotFoundException("Could not find template $templateName in $templatePrefix")
+        }
     }
 
 }

--- a/src/test/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPluginLauncherSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/daemon/OspackageDaemonPluginLauncherSpec.groovy
@@ -147,4 +147,48 @@ class OspackageDaemonPluginLauncherSpec extends IntegrationSpec {
         !postInst.contains("/usr/sbin/update-rc.d")
     }
 
+    def 'custom templates'() {
+        buildFile << """
+            ${applyPlugin(OspackageDaemonPlugin)}
+            ${applyPlugin(SystemPackagingPlugin)}
+
+            daemonsTemplates.folder = '/com/netflix/gradle/plugins/daemon/custom'
+
+            daemon {
+                daemonName = 'foobar'
+                command = 'sleep infinity'
+            }
+            """.stripIndent()
+
+        when:
+        runTasksSuccessfully('buildDeb', 'buildRpm')
+
+        then:
+        new File(projectDir, "build/distributions/${moduleName}-unspecified.noarch.rpm").exists()
+
+        def rpmTemplateDir = new File(projectDir, 'build/daemon/Foobar/buildRpm/')
+        def rpmInitFile = new File(rpmTemplateDir, 'initd')
+        rpmInitFile.exists()
+        rpmInitFile.text.contains('''
+            # chkconfig: 345 85 15
+            # description: Control Script for foobar
+
+            . /etc/rc.d/init.d/functions'''.stripIndent())
+
+        new File(projectDir, "build/distributions/${moduleName}_unspecified_all.deb").exists()
+
+        def debTemplateDir = new File(projectDir, 'build/daemon/Foobar/buildDeb/')
+        def debInitFile = new File(debTemplateDir, 'initd')
+        debInitFile.exists()
+        debInitFile.text.contains('''
+            ### BEGIN of CUSTOM SCRIPT INIT INFO
+            # Provides:          foobar
+            # Default-Start:     2 3 4 5
+            # Default-Stop:      0 1 6
+            # Required-Start:
+            # Required-Stop:
+            # Description: Control Script for foobar
+            ### END INIT INFO'''.stripIndent())
+    }
+
 }

--- a/src/test/groovy/com/netflix/gradle/plugins/daemon/TemplateHelperSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/daemon/TemplateHelperSpec.groovy
@@ -1,0 +1,41 @@
+package com.netflix.gradle.plugins.daemon
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(TemplateHelper)
+class TemplateHelperSpec extends Specification {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder()
+
+    @Rule
+    public TemporaryFolder destinationFolder = new TemporaryFolder()
+
+    def 'fails if file is not present'() {
+        TemplateHelper templateHelper = new TemplateHelper(destinationFolder.root, tmpFolder.root.path)
+
+        when:
+        templateHelper.generateFile("test", [:])
+
+        then:
+        thrown(FileNotFoundException)
+    }
+
+    def 'generates files does not fail with valid templates'() {
+        File initd = tmpFolder.newFile('initd.tpl')
+        initd.text = """
+              #!/bin/sh
+        """
+
+        TemplateHelper templateHelper = new TemplateHelper(destinationFolder.root, tmpFolder.root.path)
+
+        when:
+        templateHelper.generateFile("initd", [:])
+
+        then:
+        notThrown(FileNotFoundException)
+    }
+}

--- a/src/test/resources/com/netflix/gradle/plugins/daemon/custom/initd.tpl
+++ b/src/test/resources/com/netflix/gradle/plugins/daemon/custom/initd.tpl
@@ -1,0 +1,114 @@
+#!/bin/sh
+<% if (isRedhat) { %>
+# chkconfig: ${runLevels.join("")} ${startSequence} ${stopSequence}
+# description: Control Script for ${daemonName}
+
+. /etc/rc.d/init.d/functions
+<%
+} else {
+%>
+### BEGIN of CUSTOM SCRIPT INIT INFO
+# Provides:          ${daemonName}
+# Default-Start:     ${runLevels.join(" ")}
+# Default-Stop:      0 1 6
+# Required-Start:
+# Required-Stop:
+# Description: Control Script for ${daemonName}
+### END INIT INFO
+<% } %>
+
+service=${daemonName}
+<% if (isRedhat) { %>
+subsys_lock="/var/lock/subsys/\$service"
+<% } %>
+daemontools_service=/service/${daemonName}
+
+<% if (isRedhat) { %>
+if [ -e /etc/sysconfig/${daemonName} ]; then
+  . /etc/sysconfig/${daemonName}
+fi
+<%
+} else {
+%>
+if [ -e /etc/default/${daemonName} ]; then
+  . /etc/default/${daemonName}
+fi
+<% } %>
+
+stop() {
+    touch \$daemontools_service/down
+    svc -d \$daemontools_service
+}
+
+start() {
+    rm -f \$daemontools_service/down
+    svc -u \$daemontools_service
+}
+
+restart() {
+    svc -t \$daemontools_service
+}
+
+case \$1 in
+
+start)
+    echo -n "\${service}: "
+    start
+    if [ \$? -eq 0 ]
+    then
+<% if (isRedhat) { %>
+        success
+        touch \$subsys_lock
+    else
+        failure
+<%
+} else {
+%>
+        echo "OK"
+    else
+        echo "ERROR"
+<% } %>
+    fi
+    ;;
+ stop)
+    echo -n "\$service:  "
+    stop
+    if [ \$? -eq 0 ]
+    then
+<% if (isRedhat) { %>
+        success
+        rm -f \$subsys_lock
+    else
+        failure
+<%
+} else {
+%>
+        echo "OK"
+    else
+        echo "ERROR"
+<% } %>
+    fi
+    ;;
+restart)
+    echo -n "\$service: "
+    restart
+    if [ \$? -eq 0 ]
+    then
+<% if (isRedhat) { %>
+        success
+        touch \$subsys_lock
+    else
+        failure
+<%
+} else {
+%>
+        echo "OK"
+    else
+        echo "ERROR"
+<% } %>
+    fi
+    ;;
+  *)
+    echo "Usage: service \$service {start|stop|restart}"
+    exit 1
+esac

--- a/src/test/resources/com/netflix/gradle/plugins/daemon/custom/log-run.tpl
+++ b/src/test/resources/com/netflix/gradle/plugins/daemon/custom/log-run.tpl
@@ -1,0 +1,4 @@
+#!/bin/sh
+mkdir -p ${logDir}
+chown ${logUser} ${logDir}
+exec setuidgid ${logUser} ${logCommand}

--- a/src/test/resources/com/netflix/gradle/plugins/daemon/custom/run.tpl
+++ b/src/test/resources/com/netflix/gradle/plugins/daemon/custom/run.tpl
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec setuidgid ${user} ${command}


### PR DESCRIPTION
Historically OSPackage has provided templates for the daemon plugin:

`init`, `run`, `log-run`.

There is no easy way to override these.

This pull request suggest allows to set a property in build file as follows:

` daemonsTemplates.folder = '/com/netflix/gradle/plugins/daemon/custom'`

This will look for templates in the provided folder within the classpath (living basically in resources folder) or falling back to local filesystem in case users decide that's convenient for them. 

`daemonsTemplates.folder` is introduced in order to avoid breaking changes with the existing contract. Also simplifies things in cases where users set daemons as follows:

```
daemon {
              daemonName = "foobaz" // default = packageName
              command = "sleep infinity" // required
            }
            daemons {
                daemon {
                  // daemonName default = packageName
                  command = 'exit 0'
                }
                daemon {
                  daemonName = "foobar"
                  command = "sleep infinity" // required
                }
                daemon {
                  daemonName = "fooqux" // default = packageName
                  command = "sleep infinity" // required
                  user = "nobody" // default = "root"
                  logUser = "root" // default = "nobody"
                  logDir = "/tmp" // default = "./main"
                  logCommand = "cronolog /logs/foobar/foobar.log" // default = "multilog t ./main"
                  runLevels = [3,4] // rpm default == [3,4,5], deb default = [2,3,4,5]
                  autoStart = false // default = true
                  startSequence = 99 // default 85
                  stopSequence = 1 // default 15
                }
           
Option 2: Or upload your JavaScript file
  
Indentation level:

Brace style:

BEAUTIFY JAVASCRIPT  BEAUTIFY JAVASCRIPT IN NEW WINDOW

 
Beautified JavaScript:
daemon {
	daemonName = "foobaz" // default = packageName
	command = "sleep infinity" // required
}
daemons {
	daemon {
		// daemonName default = packageName
		command = 'exit 0'
	}
	daemon {
		daemonName = "foobar"
		command = "sleep infinity" // required
	}
	daemon {
		daemonName = "fooqux" // default = packageName
		command = "sleep infinity" // required
		user = "nobody" // default = "root"
		logUser = "root" // default = "nobody"
		logDir = "/tmp" // default = "./main"
		logCommand = "cronolog /logs/foobar/foobar.log" // default = "multilog t ./main"
		runLevels = [3, 4] // rpm default == [3,4,5], deb default = [2,3,4,5]
		autoStart = false // default = true
		startSequence = 99 // default 85
		stopSequence = 1 // default 15
	}
}
```

since you can set daemons in or out the `daemons` closure, I thought it would be ok to have the config setting outside of it, that way it prevents from setting the value on each daemon or fall into scenarios like this:

```
daemon {
	daemonName = "foobaz" // default = packageName
	command = "sleep infinity" // required
}
daemons {
       templatesFolder = '/com/netflix/gradle/plugins/daemon/custom'`
}
```

which in my opinion could be confusing.