### PR TITLE
Add support for config files on .deb

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
@@ -55,6 +55,7 @@ class Deb extends SystemPackagingTask {
         ConventionMapping mapping = ((IConventionAware) this).getConventionMapping()
 
         // Could come from extension
+        mapping.map('fileType', { parentExten?.getFileType() })
         mapping.map('uid', { parentExten?.getUid()?:0 })
         mapping.map('gid', { (parentExten?.getGid())?:0 })
         mapping.map('packageGroup', { parentExten?.getPackageGroup() ?: 'java' })

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -107,6 +107,11 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         def inputFile = extractFile(fileDetails)
 
         Directive fileType = lookup(specToLookAt, 'fileType')
+        if (fileType == CONFIG) {
+            logger.debug "mark {} as configuration file", fileDetails.relativePath.pathString
+            task.configurationFile(fileDetails.relativePath.pathString)
+        }
+
         String user = lookup(specToLookAt, 'user') ?: task.user
         Integer uid = (Integer) lookup(specToLookAt, 'uid') ?: task.uid ?: 0
         String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
@@ -114,7 +119,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
 
         int fileMode = fileDetails.mode
 
-        debFileVisitorStrategy.addFile(fileDetails, inputFile, user, fileType, uid, group, gid, fileMode)
+        debFileVisitorStrategy.addFile(fileDetails, inputFile, user, uid, group, gid, fileMode)
     }
 
     @Override

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -108,7 +108,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         def inputFile = extractFile(fileDetails)
 
         Directive fileType = lookup(specToLookAt, 'fileType')
-        if (fileType == CONFIG) {
+        if (fileType == 'CONFIG') {
             logger.debug "mark {} as configuration file", fileDetails.relativePath.pathString
             task.configurationFile(fileDetails.relativePath.pathString)
         }

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -106,6 +106,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
 
         def inputFile = extractFile(fileDetails)
 
+        Directive fileType = lookup(specToLookAt, 'fileType')
         String user = lookup(specToLookAt, 'user') ?: task.user
         Integer uid = (Integer) lookup(specToLookAt, 'uid') ?: task.uid ?: 0
         String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
@@ -113,7 +114,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
 
         int fileMode = fileDetails.mode
 
-        debFileVisitorStrategy.addFile(fileDetails, inputFile, user, uid, group, gid, fileMode)
+        debFileVisitorStrategy.addFile(fileDetails, inputFile, user, fileType, uid, group, gid, fileMode)
     }
 
     @Override

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -39,6 +39,7 @@ import org.vafer.jdeb.mapping.Mapper
 import org.vafer.jdeb.mapping.PermMapper
 import org.vafer.jdeb.producers.DataProducerLink
 import org.vafer.jdeb.producers.DataProducerPathTemplate
+import org.redline_rpm.payload.Directive
 
 import static com.netflix.gradle.plugins.utils.GradleUtils.lookup
 /**

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebFileVisitorStrategy.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebFileVisitorStrategy.groovy
@@ -20,7 +20,7 @@ class DebFileVisitorStrategy {
         this.installDirs = installDirs
     }
 
-    void addFile(FileCopyDetails details, File source, String user, int uid, String group, int gid, int mode) {
+    void addFile(FileCopyDetails details, File source, String user, Directive directive, int uid, String group, int gid, int mode) {
         try {
             File file = details.file
             File parentLink = JavaNIOUtils.parentSymbolicLink(file)

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebFileVisitorStrategy.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebFileVisitorStrategy.groovy
@@ -20,7 +20,7 @@ class DebFileVisitorStrategy {
         this.installDirs = installDirs
     }
 
-    void addFile(FileCopyDetails details, File source, String user, Directive directive, int uid, String group, int gid, int mode) {
+    void addFile(FileCopyDetails details, File source, String user, int uid, String group, int gid, int mode) {
         try {
             File file = details.file
             File parentLink = JavaNIOUtils.parentSymbolicLink(file)

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -153,7 +153,7 @@ class DebPluginTest extends ProjectSpec {
 
             from(srcDir.toString() + '/main/groovy') {
                 createDirectoryEntry true
-                fileType = CONFIG | NOREPLACE
+                fileType = CONFIG
             }
 
             from(noParentsDir) {
@@ -178,12 +178,9 @@ class DebPluginTest extends ProjectSpec {
         'optional' == scan.getHeaderEntry('Priority')
 
         scan.controlContents['./conffiles'].eachLine {
-            '/etc/init.d/served' == it
+            '/etc/init.d/served' == it || '/opt/bleah/main/groovy' == it
         }
-        scan.controlContents['./conffiles'].eachLine {
-            '/opt/bleah/main/groovy' == it
-        }
-
+        
         def file = scan.getEntry('./a/path/not/to/create/alone')
         file.isFile()
 

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -153,7 +153,7 @@ class DebPluginTest extends ProjectSpec {
 
             from(srcDir.toString() + '/main/groovy') {
                 createDirectoryEntry true
-                //fileType = CONFIG | NOREPLACE
+                fileType = CONFIG | NOREPLACE
             }
 
             from(noParentsDir) {

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -180,7 +180,10 @@ class DebPluginTest extends ProjectSpec {
         scan.controlContents['./conffiles'].eachLine {
             '/etc/init.d/served' == it
         }
-        
+        scan.controlContents['./conffiles'].eachLine {
+            '/opt/bleah/main/groovy' == it
+        }
+
         def file = scan.getEntry('./a/path/not/to/create/alone')
         file.isFile()
 


### PR DESCRIPTION
This allows mark files within a debian package as configuration ones. As it does only supports `CONFIG` string, the Deb-Plugin wiki page should be modified.  
Closes nebula-plugins/gradle-ospackage-plugin#118