### PR TITLE
 Make Deb and Rpm tasks cacheable 

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
@@ -21,10 +21,12 @@ import com.netflix.gradle.plugins.packaging.Dependency
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 
+@CacheableTask
 class Deb extends SystemPackagingTask {
     Deb() {
         super()

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -4,6 +4,8 @@ import com.netflix.gradle.plugins.deb.control.MultiArch
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.redline_rpm.header.Architecture
 import org.redline_rpm.header.Os
 import org.redline_rpm.header.RpmType
@@ -47,7 +49,7 @@ class SystemPackagingExtension {
     @Input @Optional
     String signingKeyPassphrase
 
-    @InputFile @Optional
+    @InputFile @Optional @PathSensitive(PathSensitivity.RELATIVE)
     File signingKeyRingFile
 
     // Metadata, some are probably specific to a type
@@ -158,13 +160,13 @@ class SystemPackagingExtension {
 
     // Scripts
 
-    @InputFile @Optional
+    @InputFile @Optional @PathSensitive(PathSensitivity.RELATIVE)
     File preInstallFile
-    @InputFile @Optional
+    @InputFile @Optional @PathSensitive(PathSensitivity.RELATIVE)
     File postInstallFile
-    @InputFile @Optional
+    @InputFile @Optional @PathSensitive(PathSensitivity.RELATIVE)
     File preUninstallFile
-    @InputFile @Optional
+    @InputFile @Optional @PathSensitive(PathSensitivity.RELATIVE)
     File postUninstallFile
 
     final List<Object> configurationFiles = []

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -284,6 +284,7 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
      * @return Collection of files
      */
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     @SkipWhenEmpty
     private final FileCollection getFakeFiles() {
         project.files('fake')

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
@@ -18,6 +18,7 @@ package com.netflix.gradle.plugins.rpm
 
 import com.netflix.gradle.plugins.packaging.AbstractPackagingCopyAction
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
@@ -28,6 +29,7 @@ import org.redline_rpm.header.RpmType
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
 
+@CacheableTask
 class Rpm extends SystemPackagingTask {
     @InputFile @Optional @PathSensitive(PathSensitivity.RELATIVE)
     File changeLogFile

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
@@ -20,6 +20,8 @@ import com.netflix.gradle.plugins.packaging.AbstractPackagingCopyAction
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.redline_rpm.header.Architecture
 import org.redline_rpm.header.Os
 import org.redline_rpm.header.RpmType
@@ -27,7 +29,7 @@ import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
 
 class Rpm extends SystemPackagingTask {
-    @InputFile @Optional
+    @InputFile @Optional @PathSensitive(PathSensitivity.RELATIVE)
     File changeLogFile
 
     Rpm() {

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
@@ -18,8 +18,7 @@ package com.netflix.gradle.plugins.rpm
 
 import com.netflix.gradle.plugins.packaging.AbstractPackagingCopyAction
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.redline_rpm.header.Architecture
 import org.redline_rpm.header.Os


### PR DESCRIPTION
Both tasks already support up-to-date check so only the annotation was
missing to make them cacheable.

By default, all the built-in archiving tasks are not cacheable as they
are usually quick so it's not worth it to make them cacheable. The
difference with Rpm and Deb is the output produced, if task is executed
twice from a clean workspace, is different because a time stamp is
inserted in the deb or rpm.

Making those task cacheable is worth it to not invalidate the tasks that
depends on the deb or rpm, they will be retrieved from the gradle cache
if it is enabled.