### PR TITLE
Upgraded Docker gradle dependency to 5.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
         exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
     }
 
-    compile 'com.bmuschko:gradle-docker-plugin:3.2.1'
+    compile 'com.bmuschko:gradle-docker-plugin:5.0.0'
 }
 
 def javaApiUrl = 'http://docs.oracle.com/javase/1.6.0/docs/api/'


### PR DESCRIPTION
There's a few features that have been added to the docker gradle plugin such as auto removing containers after they've stopped.  Additionally, some of the syntax in the gradle plugin has also changed a bit, so the examples in the user guide no longer work.  

This just updates the docker gradle dependency to the latest version.