### PR TITLE
Gradle 6.1.x support - deprecation warning logger for now

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  *
  */
 plugins {
-    id 'nebula.plugin-plugin' version '13.0.2'
+    id 'nebula.plugin-plugin' version '13.1.0'
     id 'java-library'
 }
 

--- a/src/main/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPlugin.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPlugin.groovy
@@ -20,9 +20,11 @@ import groovy.transform.CompileDynamic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.distribution.plugins.DistributionPlugin
+import org.gradle.api.invocation.Gradle
 import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.application.CreateStartScripts
+import org.gradle.util.GradleVersion
 
 /**
  * Combine the os-package with the Application plugin. Currently heavily opinionated to where
@@ -64,7 +66,11 @@ class OspackageApplicationSpringBootPlugin implements Plugin<Project> {
             project.afterEvaluate {
                 project.distributions {
                     boot {
-                        baseName = "${project.distributions.main.baseName}-boot"
+                        if(GradleVersion.current().baseVersion < GradleVersion.version('6.0').baseVersion) {
+                            baseName = "${project.distributions.main.baseName}-boot"
+                        } else {
+                            getDistributionBaseName().set "${project.distributions.main.getDistributionBaseName().getOrNull()}-boot"
+                        }
                     }
                 }
             }
@@ -91,5 +97,7 @@ class OspackageApplicationSpringBootPlugin implements Plugin<Project> {
                 }
             }
         }
+
+
     }
 }

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
@@ -25,21 +25,25 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.util.DeprecationLogger
 
 @CacheableTask
 class Deb extends SystemPackagingTask {
     Deb() {
         super()
-        extension = 'deb'
+        archiveExtension.set 'deb'
     }
 
     @Override
     String assembleArchiveName() {
         String name = getPackageName();
-        name += getVersion() ? "_${getVersion()}" : ''
-        name += getRelease() ? "-${getRelease()}" : ''
-        name += getArchString() ? "_${getArchString()}" : ''
-        name += getExtension() ? ".${getExtension()}" : ''
+        DeprecationLogger.whileDisabled {
+            name += getVersion() ? "_${getVersion()}" : ''
+            name += getRelease() ? "-${getRelease()}" : ''
+            name += getArchString() ? "_${getArchString()}" : ''
+            name += getArchiveExtension().getOrNull() ? ".${getArchiveExtension().getOrNull()}" : ''
+        }
+
         return name;
     }
 

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.time.DateFormatUtils
 import org.gradle.api.GradleException
 import org.gradle.api.internal.file.copy.CopyAction
 import org.gradle.api.internal.file.copy.FileCopyDetailsInternal
+import org.gradle.util.DeprecationLogger
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.vafer.jdeb.Compression
@@ -301,50 +302,59 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
      * Map to be consumed by generateFile when transforming template
      */
     def Map toContext() {
-        [
-                name: task.getPackageName(),
-                version: task.getVersion(),
-                release: task.getRelease(),
-                maintainer: task.getMaintainer(),
-                uploaders: task.getUploaders(),
-                priority: task.getPriority(),
-                epoch: task.getEpoch(),
-                description: task.getPackageDescription() ?: '',
-                distribution: task.getDistribution(),
-                summary: task.getSummary(),
-                section: task.getPackageGroup(),
-                time: DateFormatUtils.SMTP_DATETIME_FORMAT.format(new Date()),
-                provides: StringUtils.join(provides, ", "),
-                depends: StringUtils.join(dependencies, ", "),
-                url: task.getUrl(),
-                arch: task.getArchString(),
-                multiArch: getMultiArch(),
-                conflicts: StringUtils.join(conflicts, ", "),
-                recommends: StringUtils.join(recommends, ", "),
-                suggests: StringUtils.join(suggests, ", "),
-                enhances: StringUtils.join(enhances, ", " ),
-                preDepends: StringUtils.join(preDepends, ", "),
-                breaks: StringUtils.join(breaks, ", "),
-                replaces: StringUtils.join(replaces, ", "),
-                fullVersion: buildFullVersion(),
-                customFields: getCustomFields(),
+        Map context = [:]
+        DeprecationLogger.whileDisabled {
+            context = [
+                    name: task.getPackageName(),
+                    version: task.getVersion(),
+                    release: task.getRelease(),
+                    maintainer: task.getMaintainer(),
+                    uploaders: task.getUploaders(),
+                    priority: task.getPriority(),
+                    epoch: task.getEpoch(),
+                    description: task.getPackageDescription() ?: '',
+                    distribution: task.getDistribution(),
+                    summary: task.getSummary(),
+                    section: task.getPackageGroup(),
+                    time: DateFormatUtils.SMTP_DATETIME_FORMAT.format(new Date()),
+                    provides: StringUtils.join(provides, ", "),
+                    depends: StringUtils.join(dependencies, ", "),
+                    url: task.getUrl(),
+                    arch: task.getArchString(),
+                    multiArch: getMultiArch(),
+                    conflicts: StringUtils.join(conflicts, ", "),
+                    recommends: StringUtils.join(recommends, ", "),
+                    suggests: StringUtils.join(suggests, ", "),
+                    enhances: StringUtils.join(enhances, ", " ),
+                    preDepends: StringUtils.join(preDepends, ", "),
+                    breaks: StringUtils.join(breaks, ", "),
+                    replaces: StringUtils.join(replaces, ", "),
+                    fullVersion: buildFullVersion(),
+                    customFields: getCustomFields(),
 
-                // Uses install command for directory
-                dirs: installDirs.collect { InstallDir dir -> [install: installLineGenerator.generate(dir)] }
-        ]
+                    // Uses install command for directory
+                    dirs: installDirs.collect { InstallDir dir -> [install: installLineGenerator.generate(dir)] }
+            ]
+        }
+        return context
     }
 
     private String buildFullVersion() {
         StringBuilder fullVersion = new StringBuilder()
-        if (task.getEpoch() != 0) {
-            fullVersion <<= task.getEpoch()
-            fullVersion <<= ':'
-        }
-        fullVersion <<= task.getVersion()
 
-        if(task.getRelease()) {
-            fullVersion <<= '-'
-            fullVersion <<= task.getRelease()
+        DeprecationLogger.whileDisabled {
+            if (task.getEpoch() != 0) {
+                fullVersion <<= task.getEpoch()
+                fullVersion <<= ':'
+            }
+
+            fullVersion <<= task.getVersion()
+
+            if(task.getRelease()) {
+                fullVersion <<= '-'
+                fullVersion <<= task.getRelease()
+            }
+
         }
 
         fullVersion.toString()

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/validation/DebTaskPropertiesValidator.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/validation/DebTaskPropertiesValidator.groovy
@@ -4,6 +4,7 @@ import com.netflix.gradle.plugins.deb.Deb
 import com.netflix.gradle.plugins.packaging.validation.SystemPackagingAttributeValidator
 import com.netflix.gradle.plugins.packaging.validation.SystemPackagingTaskPropertiesValidator
 import org.gradle.api.InvalidUserDataException
+import org.gradle.util.DeprecationLogger
 
 class DebTaskPropertiesValidator implements SystemPackagingTaskPropertiesValidator<Deb> {
     private final SystemPackagingAttributeValidator versionValidator = new DebVersionAttributeValidator()
@@ -11,12 +12,14 @@ class DebTaskPropertiesValidator implements SystemPackagingTaskPropertiesValidat
 
     @Override
     void validate(Deb task) {
-        if(task.getVersion() != 'unspecified' && !versionValidator.validate(task.getVersion())) {
-            throw new InvalidUserDataException(versionValidator.getErrorMessage(task.getVersion()))
-        }
+        DeprecationLogger.whileDisabled {
+            if(task.getVersion() != 'unspecified' && !versionValidator.validate(task.getVersion())) {
+                throw new InvalidUserDataException(versionValidator.getErrorMessage(task.getVersion()))
+            }
 
-        if(!packageNameValidator.validate(task.getPackageName())) {
-            throw new InvalidUserDataException(packageNameValidator.getErrorMessage(task.getPackageName()))
+            if(!packageNameValidator.validate(task.getPackageName())) {
+                throw new InvalidUserDataException(packageNameValidator.getErrorMessage(task.getPackageName()))
+            }
         }
     }
 }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.util.DeprecationLogger
 import org.redline_rpm.header.Architecture
 import org.redline_rpm.header.Os
 import org.redline_rpm.header.RpmType

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.util.DeprecationLogger
 import org.redline_rpm.header.Architecture
 import org.gradle.api.provider.Property
 
@@ -48,7 +49,7 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
 
         // I have no idea where Project came from
         parentExten = project.extensions.findByType(ProjectPackagingExtension)
-        if(parentExten) {
+        if (parentExten) {
             getRootSpec().with(parentExten.delegateCopySpec)
         }
     }
@@ -58,7 +59,7 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
      * @param arch
      */
     void setArch(Object arch) {
-        setArchStr( (arch instanceof Architecture)?arch.name():arch.toString())
+        setArchStr((arch instanceof Architecture) ? arch.name() : arch.toString())
     }
 
     // TODO Move outside task, since it's specific to a plugin
@@ -67,49 +68,53 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
         // to pull from the parentExten. And only then would we fallback on some other value.
         ConventionMapping mapping = ((IConventionAware) this).getConventionMapping()
 
-        // Could come from extension
-        mapping.map('packageName', {
-            // BasePlugin defaults this to pluginConvention.getArchivesBaseName(), which in turns comes form project.name
-            parentExten?.getPackageName()?:getBaseName()
-        })
-        mapping.map('release', { parentExten?.getRelease()?:getClassifier() })
-        mapping.map('version', { sanitizeVersion(parentExten?.getVersion()?:project.getVersion().toString()) })
-        mapping.map('epoch', { parentExten?.getEpoch()?:0 })
-        mapping.map('signingKeyId', { parentExten?.getSigningKeyId()?:'' })
-        mapping.map('signingKeyPassphrase', { parentExten?.getSigningKeyPassphrase()?:'' })
-        mapping.map('signingKeyRingFile', {
-            File defaultFile = new File(System.getProperty('user.home').toString(), '.gnupg/secring.gpg')
-            parentExten?.getSigningKeyRingFile() ?: (defaultFile.exists() ? defaultFile : null)
-        })
-        mapping.map('user', { parentExten?.getUser()?:getPackager() })
-        mapping.map('maintainer', { parentExten?.getMaintainer()?:getPackager() })
-        mapping.map('uploaders', { parentExten?.getUploaders()?:getPackager() })
-        mapping.map('permissionGroup', { parentExten?.getPermissionGroup()?:'' })
-        mapping.map('packageGroup', { parentExten?.getPackageGroup() })
-        mapping.map('buildHost', { parentExten?.getBuildHost()?: HOST_NAME })
-        mapping.map('summary', { parentExten?.getSummary()?:getPackageName() })
-        mapping.map('packageDescription', {
-            String packageDescription = parentExten?.getPackageDescription()?:project.getDescription()
-            packageDescription ?: ''
-        })
-        mapping.map('license', { parentExten?.getLicense()?:'' })
-        mapping.map('packager', { parentExten?.getPackager()?:System.getProperty('user.name', '')  })
-        mapping.map('distribution', { parentExten?.getDistribution()?:'' })
-        mapping.map('vendor', { parentExten?.getVendor()?:'' })
-        mapping.map('url', { parentExten?.getUrl()?:'' })
-        mapping.map('sourcePackage', { parentExten?.getSourcePackage()?:'' })
-        mapping.map('createDirectoryEntry', { parentExten?.getCreateDirectoryEntry()?:false })
-        mapping.map('priority', { parentExten?.getPriority()?:'optional' })
+        DeprecationLogger.whileDisabled {
 
-        mapping.map('preInstallFile', { parentExten?.getPreInstallFile() })
-        mapping.map('postInstallFile', { parentExten?.getPostInstallFile() })
-        mapping.map('preUninstallFile', { parentExten?.getPreUninstallFile() })
-        mapping.map('postUninstallFile', { parentExten?.getPostUninstallFile() })
 
-        // Task Specific
-        mapping.map('archiveName', { assembleArchiveName() })
-        mapping.map('archivePath', { determineArchivePath() })
-        mapping.map('archiveFile', { determineArchiveFile() })
+            // Could come from extension
+            mapping.map('packageName', {
+                // BasePlugin defaults this to pluginConvention.getArchivesBaseName(), which in turns comes form project.name
+                parentExten?.getPackageName() ?: getArchiveBaseName().getOrNull()
+            })
+            mapping.map('release', { parentExten?.getRelease() ?: getArchiveClassifier().getOrNull() })
+            mapping.map('version', { sanitizeVersion(parentExten?.getVersion() ?: project.getVersion().toString()) })
+            mapping.map('epoch', { parentExten?.getEpoch() ?: 0 })
+            mapping.map('signingKeyId', { parentExten?.getSigningKeyId() ?: '' })
+            mapping.map('signingKeyPassphrase', { parentExten?.getSigningKeyPassphrase() ?: '' })
+            mapping.map('signingKeyRingFile', {
+                File defaultFile = new File(System.getProperty('user.home').toString(), '.gnupg/secring.gpg')
+                parentExten?.getSigningKeyRingFile() ?: (defaultFile.exists() ? defaultFile : null)
+            })
+            mapping.map('user', { parentExten?.getUser() ?: getPackager() })
+            mapping.map('maintainer', { parentExten?.getMaintainer() ?: getPackager() })
+            mapping.map('uploaders', { parentExten?.getUploaders() ?: getPackager() })
+            mapping.map('permissionGroup', { parentExten?.getPermissionGroup() ?: '' })
+            mapping.map('packageGroup', { parentExten?.getPackageGroup() })
+            mapping.map('buildHost', { parentExten?.getBuildHost() ?: HOST_NAME })
+            mapping.map('summary', { parentExten?.getSummary() ?: getPackageName() })
+            mapping.map('packageDescription', {
+                String packageDescription = parentExten?.getPackageDescription() ?: project.getDescription()
+                packageDescription ?: ''
+            })
+            mapping.map('license', { parentExten?.getLicense() ?: '' })
+            mapping.map('packager', { parentExten?.getPackager() ?: System.getProperty('user.name', '') })
+            mapping.map('distribution', { parentExten?.getDistribution() ?: '' })
+            mapping.map('vendor', { parentExten?.getVendor() ?: '' })
+            mapping.map('url', { parentExten?.getUrl() ?: '' })
+            mapping.map('sourcePackage', { parentExten?.getSourcePackage() ?: '' })
+            mapping.map('createDirectoryEntry', { parentExten?.getCreateDirectoryEntry() ?: false })
+            mapping.map('priority', { parentExten?.getPriority() ?: 'optional' })
+
+            mapping.map('preInstallFile', { parentExten?.getPreInstallFile() })
+            mapping.map('postInstallFile', { parentExten?.getPostInstallFile() })
+            mapping.map('preUninstallFile', { parentExten?.getPreUninstallFile() })
+            mapping.map('postUninstallFile', { parentExten?.getPostUninstallFile() })
+
+            // Task Specific
+            mapping.map('archiveName', { assembleArchiveName() })
+            mapping.map('archivePath', { determineArchivePath() })
+            mapping.map('archiveFile', { determineArchiveFile() })
+        }
     }
 
     String sanitizeVersion(String version) {
@@ -145,42 +150,50 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
         }
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllConfigurationFiles() {
-        return getConfigurationFiles() + (parentExten?.getConfigurationFiles()?: [])
+        return getConfigurationFiles() + (parentExten?.getConfigurationFiles() ?: [])
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllPreInstallCommands() {
         return getPreInstallCommands() + (parentExten?.getPreInstallCommands() ?: [])
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllPostInstallCommands() {
         return getPostInstallCommands() + (parentExten?.getPostInstallCommands() ?: [])
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllPreUninstallCommands() {
         return getPreUninstallCommands() + (parentExten?.getPreUninstallCommands() ?: [])
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllPostUninstallCommands() {
         return getPostUninstallCommands() + (parentExten?.getPostUninstallCommands() ?: [])
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllPreTransCommands() {
         return getPreTransCommands() + (parentExten?.getPreTransCommands() ?: [])
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllPostTransCommands() {
         return getPostTransCommands() + (parentExten?.getPostTransCommands() ?: [])
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllCommonCommands() {
         return getCommonCommands() + (parentExten?.getCommonCommands() ?: [])
     }
@@ -188,39 +201,44 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
     /**
      * @return supplementary control files consisting of a combination of Strings and Files
      */
-    @Input @Optional
+    @Input
+    @Optional
     List<Object> getAllSupplementaryControlFiles() {
         return getSupplementaryControlFiles() + (parentExten?.getSupplementaryControlFiles() ?: [])
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Link> getAllLinks() {
-        if(parentExten) {
+        if (parentExten) {
             return getLinks() + parentExten.getLinks()
         } else {
             return getLinks()
         }
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Dependency> getAllDependencies() {
-        if(parentExten) {
+        if (parentExten) {
             return getDependencies() + parentExten.getDependencies()
         } else {
             return getDependencies()
         }
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     def getAllPrefixes() {
-        if(parentExten) {
+        if (parentExten) {
             return (getPrefixes() + parentExten.getPrefixes()).unique()
         } else {
             return getPrefixes()
         }
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Dependency> getAllProvides() {
         if (parentExten) {
             return parentExten.getProvides() + getProvides()
@@ -229,7 +247,8 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
         }
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Dependency> getAllObsoletes() {
         if (parentExten) {
             return getObsoletes() + parentExten.getObsoletes()
@@ -238,7 +257,8 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
         }
     }
 
-    @Input @Optional
+    @Input
+    @Optional
     List<Dependency> getAllConflicts() {
         if (parentExten) {
             return getConflicts() + parentExten.getConflicts()

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.util.DeprecationLogger
 import org.redline_rpm.header.Architecture
 import org.redline_rpm.header.Os
 import org.redline_rpm.header.RpmType
@@ -36,16 +37,19 @@ class Rpm extends SystemPackagingTask {
 
     Rpm() {
         super()
-        extension = 'rpm'
+        archiveExtension.set 'rpm'
     }
 
     @Override
     String assembleArchiveName() {
         String name = getPackageName();
-        name += getVersion() ? "-${getVersion()}" : ''
-        name += getRelease() ? "-${getRelease()}" : ''
-        name += getArchString() ? ".${getArchString()}" : ''
-        name += getExtension() ? ".${getExtension()}" : ''
+        DeprecationLogger.whileDisabled {
+            name += getVersion() ? "-${getVersion()}" : ''
+            name += getRelease() ? "-${getRelease()}" : ''
+            name += getArchString() ? ".${getArchString()}" : ''
+            name += getArchiveExtension().getOrNull() ? ".${getArchiveExtension().getOrNull()}" : ''
+        }
+
         return name;
     }
 

--- a/src/test/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPluginLauncherSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPluginLauncherSpec.groovy
@@ -84,7 +84,7 @@ class OspackageApplicationSpringBootPluginLauncherSpec extends IntegrationSpec {
         buildFile << buildScript(bootVersion, null)
 
         when:
-        runTasksSuccessfully('buildDeb')
+        runTasksSuccessfully('buildDeb', '--warning-mode', 'all')
 
         then:
         final archivePath = file("build/distributions/test_unspecified_all.deb")
@@ -123,7 +123,7 @@ class OspackageApplicationSpringBootPluginLauncherSpec extends IntegrationSpec {
         buildFile << buildScript(bootVersion, startScript)
 
         when:
-        def result = runTasksSuccessfully('runStartScript')
+        def result = runTasksSuccessfully('runStartScript', '--warning-mode', 'all')
 
         then:
         result.standardOutput.contains('Hello Integration Test')

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginIntegrationTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginIntegrationTest.groovy
@@ -72,12 +72,12 @@ ospackage {
 apply plugin: 'nebula.rpm'
 
 task buildRpm(type: Rpm) {
-    version = '1'
+    version '1'
 }
 """
 
         when:
-        runTasksSuccessfully('buildRpm')
+        runTasksSuccessfully('buildRpm', '--warning-mode', 'none')
 
         then:
         def scan = Scanner.scan(file('build/distributions/projectNameDefault-1.noarch.rpm'))
@@ -303,13 +303,13 @@ apply plugin: 'nebula.rpm'
 
 task buildRpm(type: Rpm) {
     packageName = 'example'
-    version = '3'
+    version '3'
     from 'package'
 }
 """
 
         when:
-        runTasksSuccessfully('buildRpm')
+        runTasksSuccessfully('buildRpm', '--warning-mode', 'none')
 
         then:
         def scan = Scanner.scan(this.file('build/distributions/example-3.noarch.rpm'))
@@ -332,7 +332,7 @@ apply plugin: 'nebula.rpm'
 
 task buildRpm(type: Rpm) {
     packageName = 'example'
-    version = '4'
+    version '4'
     from('package') {
         into '/lib'
     }
@@ -340,7 +340,7 @@ task buildRpm(type: Rpm) {
 """
 
         when:
-        runTasksSuccessfully('buildRpm')
+        runTasksSuccessfully('buildRpm', '--warning-mode', 'none')
 
         then:
         def scan = Scanner.scan(this.file('build/distributions/example-4.noarch.rpm'))


### PR DESCRIPTION
For now, im using deprecation logger for `getVersion()` as it needs some work to avoid issues between `AbstractArchiveTask.getVersion()` `AbstractArchiveTask.getArchiveVersion()` and 
`SystemPackagingExtension.getVersion()`

Migrated other things such as `archiveClassifier` `archiveBaseName`