### PR TITLE
Add support for versioning virtual package provides to DEB packages

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -159,7 +159,11 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
 
     @Override
     protected void addProvides(Dependency dep) {
-        provides << dep.packageName
+        String providesString = dep.packageName
+        if (dep.version) {
+            providesString += " (= ${dep.version})"
+        }
+        provides << providesString
     }
 
     @Override

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -3,11 +3,11 @@ package com.netflix.gradle.plugins.packaging
 import com.netflix.gradle.plugins.deb.control.MultiArch
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.redline_rpm.header.Architecture
+import org.redline_rpm.header.Flags
 import org.redline_rpm.header.Os
 import org.redline_rpm.header.RpmType
 import org.redline_rpm.payload.Directive
@@ -769,6 +769,10 @@ class SystemPackagingExtension {
         def dep = new Dependency(packageName, version, flag)
         provides.add(dep)
         dep
+    }
+
+    Dependency provides(String packageName, String version) {
+        provides(packageName, version, Flags.EQUAL)
     }
 
     Dependency provides(String packageName) {

--- a/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/deb/DebPluginTest.groovy
@@ -1097,6 +1097,25 @@ class DebPluginTest extends ProjectSpec {
         'someVirtualPackage, someOtherVirtualPackage' == scan.getHeaderEntry('Provides')
     }
 
+    @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/365")
+    def 'Can specify provides with version'() {
+        given:
+        project.apply plugin: 'nebula.deb'
+
+        Deb debTask = project.task([type: Deb], 'buildDeb', {
+            packageName = 'allows-multiple-provides-with-versions'
+            provides 'virtualPackageA', '1.2.3'
+            provides 'virtualPackageB'
+        })
+
+        when:
+        debTask.copy()
+
+        then:
+        def scan = new Scanner(debTask.archivePath)
+        'virtualPackageA (= 1.2.3), virtualPackageB' == scan.getHeaderEntry('Provides')
+    }
+
     @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/115")
     def 'directory construct'() {
         given:


### PR DESCRIPTION
Fixes #365.

My first PR, so any/all feedback appreciated! I tried to keep to the style already used and not do anything breaking.

* Adds logic to include the version for provides, if set, in the `DebCopyAction`. It is assumed this will always be an `=` relation, based on Debian packaging policy.
* Adds a new `provides(packageName, packageVersion)` method to the `SystemPackagingExtension`, assuming (again) this will always be an `=` relation, for both RPM and DEB (I have yet to see otherwise for RPM).
* Added test for provides with version for `buildDeb`
* Added test for propagation of provides with version from `ospackage` to `buildDeb` and `buildRpm`
* `SystemPackagingExtension` and `SystemPackagingBasePluginTest` each had an unused import that my IDE cleaned up (since the files were being touched anyway I assume this is acceptable).