### PR TITLE
Tests to show broken behavior when a symlink is named lib

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/utils/GradleUtils.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/utils/GradleUtils.groovy
@@ -2,6 +2,8 @@ package com.netflix.gradle.plugins.utils
 
 import org.gradle.api.file.FileCopyDetails
 
+import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
 
 final class GradleUtils {
@@ -41,6 +43,13 @@ final class GradleUtils {
             File sourceRoot = new File("/$sourceBase", sourceRelative)
             File targetRoot = new File("/$sourceBase", targetPath.substring(sourceBasePath.length()))
             Path relativeTarget = sourceRoot.isDirectory() ? sourceRoot.toPath().relativize(targetRoot.toPath()) : sourceRoot.parentFile.toPath().relativize(targetRoot.toPath())
+            println sourceBase
+            println sourceRelative
+            println Files.isSymbolicLink(sourceRoot.toPath())
+            println Files.isDirectory(sourceRoot.toPath())
+            println Files.isDirectory(sourceRoot.toPath(), LinkOption.NOFOLLOW_LINKS)
+            println sourceRoot.isDirectory()
+            println relativeTarget
             return new Tuple2(sourceRoot.path, relativeTarget.toString())
         } else {
             return null

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/Scanner.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/Scanner.groovy
@@ -70,7 +70,7 @@ class Scanner {
             header = new CpioHeader()
             total = header.read(wrapper, total)
             final int fileSize = header.getFileSize()
-            boolean includingContents = includeContents&&header.type==8
+            boolean includingContents = includeContents&&(header.type==8||header.type==10)
             if (!header.isLast()) {
                 ByteBuffer descriptor = includingContents?Util.fill(wrapper, fileSize):null
                 files += new ScannerFile(header, descriptor)

--- a/src/test/groovy/com/netflix/gradle/plugins/utils/GradleUtilsIntegrationTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/utils/GradleUtilsIntegrationTest.groovy
@@ -1,0 +1,75 @@
+package com.netflix.gradle.plugins.utils
+
+import static org.redline_rpm.payload.CpioHeader.SYMLINK
+
+import com.netflix.gradle.plugins.rpm.Scanner
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class GradleUtilsIntegrationTest extends IntegrationSpec {
+
+    def 'verifySymlinkDirNested'() {
+        given:
+        File rootSourceFile = createFile('source/sourceDir/subdir/text.txt')
+        Path link = Paths.get(projectDir.absolutePath, 'source','notlib')
+        Files.createSymbolicLink(link, rootSourceFile.parentFile.toPath())
+
+        buildFile << """
+apply plugin: 'nebula.rpm'
+
+task buildRpm(type: Rpm) {
+    packageName 'test'
+    from('source') {
+        into('/usr/local/')
+    }
+}
+"""
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('buildRpm')
+        println result.standardOutput
+
+        then:
+        File archive = new File(projectDir, 'build/distributions/test-0.noarch.rpm')
+        archive.exists()
+        Scanner.ScannerResult scan = Scanner.scan(archive)
+        Scanner.ScannerFile linkFile = scan.files.find { it.name == './usr/local/notlib'}
+        linkFile.type == SYMLINK
+        linkFile.asString() == 'sourceDir/subdir'
+    }
+
+    def 'verifySymlinkDirNestedWithLib'() {
+        given:
+        File rootSourceFile = createFile('source/sourceDir/subdir/text.txt')
+        Path link = Paths.get(projectDir.absolutePath, 'source','lib')
+        Files.createSymbolicLink(link, rootSourceFile.parentFile.toPath())
+
+        buildFile << """
+apply plugin: 'nebula.rpm'
+
+task buildRpm(type: Rpm) {
+    packageName 'test'
+    from('source') {
+        into('/usr/local/')
+    }
+}
+"""
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('buildRpm')
+        println result.standardOutput
+
+        then:
+        File archive = new File(projectDir, 'build/distributions/test-0.noarch.rpm')
+        archive.exists()
+        Scanner.ScannerResult scan = Scanner.scan(archive)
+        Scanner.ScannerFile linkFile = scan.files.find { it.name == './usr/local/lib'}
+        linkFile.type == SYMLINK
+        linkFile.asString() == 'sourceDir/subdir'
+    }
+
+}


### PR DESCRIPTION
These two tests are exactly the same expect one has a symlink named `lib` and the other is `notlib` (`notlib` can be anything and it works).  The symlink named `lib` fails as it does not recognizes the file as a directory, but it is not since it is a link.  It needs the relative path of the parent.

The link that is generated when the link is named `lib` has an extra `../` prefixed to it which makes it invalid.

I don't understand why the name of the link would make a difference here.  Do you have any insight?