### PR TITLE
feat(jdeb): enable long filename support

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -265,6 +265,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         File debFile = task.getArchiveFile().get().asFile
         maker.setControl(debianDir)
         maker.setDeb(debFile)
+        maker.setTarLongFileMode('posix')
         if (StringUtils.isNotBlank(task.getSigningKeyId())
                 && StringUtils.isNotBlank(task.getSigningKeyPassphrase())
                 && task.getSigningKeyRingFile().exists()) {


### PR DESCRIPTION
Recently had a build* fail as a result of an obnoxiously long filename exceeding the limit for pre-posix tar (100 characters):

```
Caused by: java.lang.IllegalArgumentException: Field '../redacted/path/that/is/long/and/-/you/guessed/it/-/has/node_modules/in/it/several/times' too long, maximum is 100
```

Wanted to see if it would be reasonable to enable longer filenames. 

First time listener, first time caller to this repo—I'm not comfortable making this change as it stands but wanted to open the door with a (potential?) fix rather than just an issue.

Close with reckless abandon as necessary. 😁

\* - I can send the build link to anyone looking in here who also happens to be a coworker.