### PR TITLE
Revert "feat(jdeb): enable long filename support"

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -265,7 +265,6 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         File debFile = task.getArchiveFile().get().asFile
         maker.setControl(debianDir)
         maker.setDeb(debFile)
-        maker.setTarLongFileMode('posix')
         if (StringUtils.isNotBlank(task.getSigningKeyId())
                 && StringUtils.isNotBlank(task.getSigningKeyPassphrase())
                 && task.getSigningKeyRingFile().exists()) {


### PR DESCRIPTION
This reverts commit 6c36b7bfa889bc772d7219be3c106615ab51dffc.