### PR TITLE
Previous users of this plugin might have used the springBoot extension

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPlugin.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPlugin.groovy
@@ -75,6 +75,10 @@ class OspackageApplicationSpringBootPlugin implements Plugin<Project> {
                         }
                     }
                 }
+                // Allow the springBoot extension configuration to propagate to the application plugin
+                if (!project.application.mainClass.isPresent()) {
+                    project.application.mainClass.set(project.springBoot.mainClassName)
+                }
             }
         } else {
             project.tasks.getByName(DistributionPlugin.TASK_INSTALL_NAME).dependsOn('bootRepackage')

--- a/src/test/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPluginLauncherSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPluginLauncherSpec.groovy
@@ -123,6 +123,31 @@ class OspackageApplicationSpringBootPluginLauncherSpec extends IntegrationSpec {
     }
 
     @Unroll
+    def 'application runs for boot #bootVersion when mainClassName configured using springBoot extension'() {
+        final applicationDir = "$moduleName-boot"
+        final startScript = file("build/install/$applicationDir/bin/$moduleName")
+
+        buildFile << buildScript(bootVersion, startScript)
+        buildFile << """
+        mainClassName = null
+
+        springBoot {
+            mainClassName = 'nebula.test.HelloWorld'
+        }
+        """
+
+        when:
+        def result = runTasksSuccessfully('runStartScript')
+
+        then:
+        result.standardOutput.contains('Hello Integration Test')
+
+        where:
+        bootVersion | _
+        '2.4.2'     | _
+    }
+
+    @Unroll
     def 'can customize destination for boot #bootVersion'() {
         buildFile << buildScript(bootVersion, null)
         buildFile << """


### PR DESCRIPTION
Use the `springBoot` extension to configure the application plugin allowing backwards compatibility with existing projects.