### PR TITLE
bootJar and jar task output name is the same which can cause overriding and bundling wrong jar in debian

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPlugin.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPlugin.groovy
@@ -68,6 +68,13 @@ class OspackageApplicationSpringBootPlugin implements Plugin<Project> {
                 enabled = true
             }
             project.afterEvaluate {
+                project.bootJar {
+                    if(GradleVersion.current().baseVersion < GradleVersion.version('6.0').baseVersion) {
+                        classifier = "boot"
+                    } else {
+                        archiveClassifier = "boot"
+                    }
+                }
                 project.distributions {
                     main {
                         if(GradleVersion.current().baseVersion < GradleVersion.version('6.0').baseVersion) {


### PR DESCRIPTION
Applying recommendation from spring documentation https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#packaging-executable-and-normal