### PR TITLE
Fix StackOverflowError in  SystemPackagingTask when using Gradle 7.0 milestones

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
+import org.gradle.api.internal.file.copy.CopyAction
+import org.gradle.api.internal.file.copy.CopyActionExecuter
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
@@ -165,7 +167,7 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
     @CompileDynamic
     protected void copy() {
         use(CopySpecEnhancement) {
-            super.copy()
+           super.copy()
         }
     }
 

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -167,7 +167,10 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
     @CompileDynamic
     protected void copy() {
         use(CopySpecEnhancement) {
-           super.copy()
+            CopyActionExecuter copyActionExecuter = this.createCopyActionExecuter();
+            CopyAction copyAction = this.createCopyAction();
+            WorkResult didWork = copyActionExecuter.execute(this.rootSpec, copyAction);
+            this.setDidWork(didWork.getDidWork());
         }
     }
 


### PR DESCRIPTION
This is a simple fix for #393 by just moving the build logic referenced by super.copy() directly into `SystemPackagingTask.copy`