### PR TITLE
preinst should run during upgrade

### DIFF
--- a/src/main/resources/deb/preinst.ftl
+++ b/src/main/resources/deb/preinst.ftl
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 case "\$1" in
-    install)
+    install|upgrade)
         <% commands.each {command -> %>
         <%= command %>
         <% } %>


### PR DESCRIPTION
The intention of this PR is to fix the following issue: https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/251