### PR TITLE
fix issue 416 - merge directories from extension to task configuration

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/AbstractPackagingCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/AbstractPackagingCopyAction.groovy
@@ -107,7 +107,7 @@ abstract class AbstractPackagingCopyAction<T extends SystemPackagingTask> implem
             addProvides(provides)
         }
 
-        task.directories.each { directory ->
+        for (Directory directory: task.getAllDirectories()) {
             logger.debug "adding directory {}", directory.path
             addDirectory(directory)
         }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -323,6 +323,16 @@ abstract class SystemPackagingTask extends AbstractArchiveTask {
         }
     }
 
+    @Input
+    @Optional
+    List<Directory> getAllDirectories() {
+        if (parentExten) {
+            return getDirectories() + parentExten.getDirectories()
+        } else {
+            return getDirectories()
+        }
+    }
+
     @Override
     abstract AbstractPackagingCopyAction createCopyAction()
 

--- a/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginIntegrationTest.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/rpm/RpmPluginIntegrationTest.groovy
@@ -346,4 +346,35 @@ task buildRpm(type: Rpm) {
         def symlink = scan.files.find { it.name == './lib/bin/my-symlink' }
         symlink.header.type == SYMLINK
     }
+
+    @Issue("https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/416")
+    def 'directory entries in ospackage extension propagates to rpm and deb'() {
+        given:
+        File bananaFile = new File(projectDir, 'test/banana')
+        FileUtils.forceMkdirParent(bananaFile)
+        bananaFile.text = 'banana'
+
+        buildFile << """
+apply plugin: 'com.netflix.nebula.rpm'
+apply plugin: 'com.netflix.nebula.ospackage-base'
+version = '1.0.0'
+
+ospackage {
+    directory('/usr/share/myproduct/from-extension')
+}
+task buildRpm(type: Rpm) {
+    packageName = 'sample'    
+    directory('/usr/share/myproduct/from-task')
+}
+"""
+        when:
+        runTasksSuccessfully('buildRpm')
+
+        then:
+        // Evaluate response
+        def scanFiles = Scanner.scan(file('build/distributions/sample-1.0.0.noarch.rpm')).files
+
+        ['./usr/share/myproduct/from-extension', './usr/share/myproduct/from-task'] == scanFiles*.name
+        [ DIR, DIR] == scanFiles*.type
+    }
 }


### PR DESCRIPTION
this PR fixes issue 416,  we should be able to define `directory` directly in the ospackage extension.