### PR TITLE
update readme to fix link to gradle plugin portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ documentation. All the plugins are pure-java and don't require any local native 
 
 # Quick Start
 
-Refer to the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/nebula.ospackage) for instructions on how to apply the main plugin.
+Refer to the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.netflix.nebula.ospackage) for instructions on how to apply the main plugin.
 
 # Documentation
 


### PR DESCRIPTION
Update link to point to correct version of this plugin in Gradle plugin portail, after namespace has been changed to `com.netflix.nebula.ospackage`