### PR TITLE
Add explicit setgid support to Rpm and Deb tasks

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -135,9 +135,12 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
             Integer uid = (Integer) lookup(specToLookAt, 'uid') ?: task.uid ?: 0
             String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
             Integer gid = (Integer) lookup(specToLookAt, 'gid') ?: task.gid ?: 0
+            String setgid = lookup(specToLookAt, 'setgid') ?: task.setgid
 
             int fileMode = dirDetails.mode
-
+            if (setgid) {
+                fileMode = fileMode | 02000
+            }
             debFileVisitorStrategy.addDirectory(dirDetails, user, uid, group, gid, fileMode)
         }
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/CopySpecEnhancement.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/CopySpecEnhancement.groovy
@@ -49,6 +49,14 @@ class CopySpecEnhancement {
         user(spec, userArg)
     }
 
+    static void setgid(CopySpec spec, boolean setgid) {
+        appendFieldToCopySpec(spec, 'setgid', setgid)
+    }
+
+    static void setSetgid(CopySpec spec, boolean setgid) {
+        setgid(spec, setgid)
+    }
+
     static void permissionGroup(CopySpec spec, String permissionGroup) {
         appendFieldToCopySpec(spec, 'permissionGroup', permissionGroup)
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -47,7 +47,7 @@ class SystemPackagingExtension {
     File signingKeyRingFile
     String user
     String permissionGroup // Group is used by Gradle on tasks.
-    boolean setgid
+    Boolean setgid
 
     /**
      * In Debian, this is the Section and has to be provided. Valid values are: admin, cli-mono, comm, database, debug,
@@ -184,7 +184,7 @@ class SystemPackagingExtension {
 
     @Input
     @Optional
-    String getSetgid() {
+    Boolean getSetgid() {
         return setgid
     }
 

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -47,6 +47,8 @@ class SystemPackagingExtension {
     File signingKeyRingFile
     String user
     String permissionGroup // Group is used by Gradle on tasks.
+    boolean setgid
+
     /**
      * In Debian, this is the Section and has to be provided. Valid values are: admin, cli-mono, comm, database, debug,
      * devel, doc, editors, education, electronics, embedded, fonts, games, gnome, gnu-r, gnustep, graphics, hamradio,
@@ -178,6 +180,12 @@ class SystemPackagingExtension {
     @Optional
     String getPermissionGroup() {
         return permissionGroup
+    }
+
+    @Input
+    @Optional
+    String getSetgid() {
+        return setgid
     }
 
     @Input

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -103,6 +103,7 @@ abstract class SystemPackagingTask extends OsPackageAbstractArchiveTask {
             mapping.map('maintainer', { parentExten?.getMaintainer() ?: getPackager() })
             mapping.map('uploaders', { parentExten?.getUploaders() ?: getPackager() })
             mapping.map('permissionGroup', { parentExten?.getPermissionGroup() ?: '' })
+            mapping.map('setgid', { parentExten?.getSetgid() ?: false })
             mapping.map('packageGroup', { parentExten?.getPackageGroup() })
             mapping.map('buildHost', { parentExten?.getBuildHost() ?: HOST_NAME })
             mapping.map('summary', { parentExten?.getSummary() ?: getPackageName() })

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -186,7 +186,10 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
             Directive directive = (Directive) lookup(specToLookAt, 'fileType') ?: task.fileType
             String user = lookup(specToLookAt, 'user') ?: task.user
             String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
-
+            String setgid = lookup(specToLookAt, 'setgid') ?: task.setgid
+            if (setgid) {
+                dirMode = dirMode | 02000
+            }
             rpmFileVisitorStrategy.addDirectory(dirDetails, dirMode, directive, user, group, addParentsDir)
         }
     }


### PR DESCRIPTION
With gradle 8.3 it is no longer possible to configure setgid via dirMode using 02000 permissions. This PR addresses this by introducing a dedicated property to enable setgid support. This issue is blocking our team (elasticsearch) to update to gradle 8.3. We tested this in our elasticsearch build already with a snapshots of this plugin using jitpack

see https://github.com/elastic/elasticsearch/pull/97838