### PR TITLE
Add user and group to symlinks in rpm

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/Link.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/Link.groovy
@@ -23,4 +23,6 @@ class Link implements Serializable {
     String path
     String target
     int permissions = -1
+    String user = null
+    String permissionGroup = null
 }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -777,14 +777,24 @@ class SystemPackagingExtension {
 
 
     Link link(String path, String target) {
-        link(path, target, -1)
+        link(path, target, -1, null, null)
     }
 
     Link link(String path, String target, int permissions) {
+        link(path, target, permissions, null, null)
+    }
+
+    Link link(String path, String target, String user, String permissionGroup) {
+        link(path, target, -1, user, permissionGroup)
+    }
+
+    Link link(String path, String target, int permissions, String user, String permissionGroup) {
         Link link = new Link()
         link.path = path
         link.target = target
         link.permissions = permissions
+        link.user = user
+        link.permissionGroup = permissionGroup
         links.add(link)
         link
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -196,7 +196,9 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
 
     @Override
     protected void addLink(Link link) {
-        builder.addLink link.path, link.target, link.permissions
+        def user = link.user ?: task.user
+        def permissionGroup = link.permissionGroup ?: task.permissionGroup
+        builder.addLink(link.path, link.target, link.permissions, user, permissionGroup)
     }
 
     @Override


### PR DESCRIPTION
Adds possibility to add user and permissionGroup to symlinks in rpm, defaults to task settings.

* Resolves #320.