### PR TITLE
Fix dirMode handling and setgid fallback

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -131,20 +131,21 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         def specCreateDirectoryEntry = lookup(specToLookAt, 'createDirectoryEntry')
         boolean createDirectoryEntry = specCreateDirectoryEntry!=null ? specCreateDirectoryEntry : task.createDirectoryEntry
         if (createDirectoryEntry) {
-
             logger.debug "adding directory {}", dirDetails.relativePath.pathString
             String user = lookup(specToLookAt, 'user') ?: task.user
             Integer uid = (Integer) lookup(specToLookAt, 'uid') ?: task.uid ?: 0
             String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
             Integer gid = (Integer) lookup(specToLookAt, 'gid') ?: task.gid ?: 0
-            Boolean setgid = lookup(specToLookAt, 'setgid') ?: task.setgid
+            Boolean setgid = lookup(specToLookAt, 'setgid')
 
-            int fileMode = FilePermissionUtil.getUnixPermission(dirDetails)
-
-            if (setgid) {
-                fileMode = fileMode | 02000
+            int dirMode = FilePermissionUtil.getUnixPermission(dirDetails)
+            if (setgid == null) {
+                setgid = task.setgid
             }
-            debFileVisitorStrategy.addDirectory(dirDetails, user, uid, group, gid, fileMode)
+            if (setgid) {
+                dirMode = dirMode | 02000
+            }
+            debFileVisitorStrategy.addDirectory(dirDetails, user, uid, group, gid, dirMode)
         }
     }
 

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -47,7 +47,7 @@ class SystemPackagingExtension {
     File signingKeyRingFile
     String user
     String permissionGroup // Group is used by Gradle on tasks.
-    Boolean setgid
+    boolean setgid
 
     /**
      * In Debian, this is the Section and has to be provided. Valid values are: admin, cli-mono, comm, database, debug,

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -36,8 +36,6 @@ import org.redline_rpm.payload.Directive
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import java.nio.channels.FileChannel
-
 import static com.netflix.gradle.plugins.utils.GradleUtils.lookup
 
 @CompileDynamic
@@ -183,11 +181,14 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
 
         if (createDirectoryEntry) {
             logger.debug 'adding directory {}', dirDetails.relativePath.pathString
-            int dirMode = lookup(specToLookAt, 'dirMode') ?: FilePermissionUtil.getUnixPermission(dirDetails)
+            int dirMode = FilePermissionUtil.getDirMode(specToLookAt) ?: FilePermissionUtil.getUnixPermission(dirDetails)
             Directive directive = (Directive) lookup(specToLookAt, 'fileType') ?: task.fileType
             String user = lookup(specToLookAt, 'user') ?: task.user
             String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
-            Boolean setgid = lookup(specToLookAt, 'setgid') ?: task.setgid
+            Boolean setgid = lookup(specToLookAt, 'setgid')
+            if (setgid == null) {
+                setgid = task.setgid
+            }
             if (setgid) {
                 dirMode = dirMode | 02000
             }


### PR DESCRIPTION
This fixes an incompatibility with Gradle 8.8 which threw a deprecation warning and fixes an issue in setgid handling where 
fallback is never triggered