### PR TITLE
Add explicit setuid support for RPM and Deb tasks

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -120,8 +120,15 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         Integer uid = (Integer) lookup(specToLookAt, 'uid') ?: task.uid ?: 0
         String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
         Integer gid = (Integer) lookup(specToLookAt, 'gid') ?: task.gid ?: 0
+        Boolean setuid = lookup(specToLookAt, 'setuid')
 
         int fileMode = FilePermissionUtil.getUnixPermission(fileDetails)
+        if (setuid == null) {
+            setuid = task.setuid
+        }
+        if (setuid) {
+            fileMode = fileMode | 04000
+        }
 
         debFileVisitorStrategy.addFile(fileDetails, inputFile, user, uid, group, gid, fileMode)
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/CopySpecEnhancement.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/CopySpecEnhancement.groovy
@@ -57,6 +57,14 @@ class CopySpecEnhancement {
         setgid(spec, setgid)
     }
 
+    static void setuid(CopySpec spec, boolean setuid) {
+        appendFieldToCopySpec(spec, 'setuid', setuid)
+    }
+
+    static void setSetuid(CopySpec spec, boolean setuid) {
+        setuid(spec, setuid)
+    }
+
     static void permissionGroup(CopySpec spec, String permissionGroup) {
         appendFieldToCopySpec(spec, 'permissionGroup', permissionGroup)
     }

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingExtension.groovy
@@ -48,6 +48,7 @@ class SystemPackagingExtension {
     String user
     String permissionGroup // Group is used by Gradle on tasks.
     boolean setgid
+    boolean setuid
 
     /**
      * In Debian, this is the Section and has to be provided. Valid values are: admin, cli-mono, comm, database, debug,
@@ -186,6 +187,12 @@ class SystemPackagingExtension {
     @Optional
     Boolean getSetgid() {
         return setgid
+    }
+
+    @Input
+    @Optional
+    Boolean getSetuid() {
+        return setuid
     }
 
     @Input

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -105,6 +105,7 @@ abstract class SystemPackagingTask extends OsPackageAbstractArchiveTask {
             mapping.map('uploaders', { parentExten?.getUploaders() ?: getPackager() })
             mapping.map('permissionGroup', { parentExten?.getPermissionGroup() ?: '' })
             mapping.map('setgid', { parentExten?.getSetgid() ?: false })
+            mapping.map('setuid', { parentExten?.getSetuid() ?: false })
             mapping.map('packageGroup', { parentExten?.getPackageGroup() })
             mapping.map('buildHost', { parentExten?.getBuildHost() ?: HOST_NAME })
             mapping.map('summary', { parentExten?.getSummary() ?: getPackageName() })

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -161,6 +161,13 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
         String group = lookup(specToLookAt, 'permissionGroup') ?: task.permissionGroup
 
         int fileMode =  FilePermissionUtil.getFileMode(specToLookAt) ?: FilePermissionUtil.getUnixPermission(fileDetails)
+        Boolean setuid = lookup(specToLookAt, 'setuid')
+        if (setuid == null) {
+            setuid = task.setuid
+        }
+        if (setuid) {
+            fileMode = fileMode | 04000
+        }
         def specAddParentsDir = lookup(specToLookAt, 'addParentDirs')
         boolean addParentsDir = specAddParentsDir != null ? specAddParentsDir : task.addParentDirs
 


### PR DESCRIPTION
Taking the setgid changes in #429, #438, and #443 and applying them to the setgid flag for files, for compatibility with Gradle 8.3 and beyond.