### PR TITLE
Truncate existing RPM file before writing new one

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/RpmCopyAction.groovy
@@ -236,6 +236,7 @@ class RpmCopyAction extends AbstractPackagingCopyAction<Rpm> {
         RandomAccessFile rpmFile
         try {
             rpmFile = new RandomAccessFile(task.getArchiveFile().get().asFile, "rw")
+            rpmFile.setLength(0);
             builder.build(rpmFile.getChannel())
             logger.info 'Created rpm {}', rpmFile
         } finally {


### PR DESCRIPTION
Fixes #420

I'd love to provide a test for this, too. But I simply don't have the time for it.