### PR TITLE
Fix Gradle 8.12 deprecation warning

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
@@ -20,7 +20,6 @@ import com.netflix.gradle.plugins.packaging.AbstractPackagingCopyAction
 import com.netflix.gradle.plugins.packaging.Dependency
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
 import com.netflix.gradle.plugins.utils.DeprecationLoggerUtils
-import org.gradle.api.Project
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
@@ -30,7 +29,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.work.DisableCachingByDefault
 
 import javax.inject.Inject
-
 
 @DisableCachingByDefault
 class Deb extends SystemPackagingTask {

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/Deb.groovy
@@ -20,6 +20,8 @@ import com.netflix.gradle.plugins.packaging.AbstractPackagingCopyAction
 import com.netflix.gradle.plugins.packaging.Dependency
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
 import com.netflix.gradle.plugins.utils.DeprecationLoggerUtils
+import org.gradle.api.Project
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.tasks.Input
@@ -27,11 +29,15 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.work.DisableCachingByDefault
 
+import javax.inject.Inject
+
 
 @DisableCachingByDefault
 class Deb extends SystemPackagingTask {
-    Deb() {
-        super()
+
+    @Inject
+    Deb(ProjectLayout projectLayout) {
+        super(projectLayout)
         archiveExtension.set 'deb'
         notCompatibleWithConfigurationCache("nebula.ospackage does not support configuration cache")
     }
@@ -51,7 +57,7 @@ class Deb extends SystemPackagingTask {
 
     @Override
     AbstractPackagingCopyAction createCopyAction() {
-        return new DebCopyAction(this)
+        return new DebCopyAction(this, new File(projectLayout.buildDirectory.getAsFile().get(), "debian"))
     }
 
     @Override

--- a/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/deb/DebCopyAction.groovy
@@ -68,7 +68,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
     private final MaintainerScriptsGenerator maintainerScriptsGenerator
     private final InstallLineGenerator installLineGenerator
 
-    DebCopyAction(Deb debTask) {
+    DebCopyAction(Deb debTask, File debianDir) {
         super(debTask)
         debTaskPropertiesValidator.validate(debTask)
         dependencies = []
@@ -82,7 +82,7 @@ class DebCopyAction extends AbstractPackagingCopyAction<Deb> {
         dataProducers = []
         installDirs = []
         provides = []
-        debianDir = new File(task.project.layout.buildDirectory.getAsFile().get(), "debian")
+        this.debianDir = debianDir
         debFileVisitorStrategy = new DebFileVisitorStrategy(dataProducers, installDirs)
         maintainerScriptsGenerator = new MaintainerScriptsGenerator(debTask, new TemplateHelper(debianDir, '/deb'), debianDir, new ApacheCommonsFileSystemActions())
         installLineGenerator = new InstallLineGenerator()

--- a/src/main/groovy/com/netflix/gradle/plugins/docker/SystemPackageDockerfile.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/docker/SystemPackageDockerfile.groovy
@@ -2,15 +2,20 @@ package com.netflix.gradle.plugins.docker
 
 import com.netflix.gradle.plugins.packaging.AbstractPackagingCopyAction
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
+import org.gradle.api.file.ProjectLayout
 import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.work.DisableCachingByDefault
+
+import javax.inject.Inject
 
 @DisableCachingByDefault
 class SystemPackageDockerfile extends SystemPackagingTask {
     private final DockerfileInstructionManager dockerfileInstructionManager
     private static final ARCHIVE_NAME = 'Dockerfile'
 
-    SystemPackageDockerfile() {
+    @Inject
+    SystemPackageDockerfile(ProjectLayout projectLayout) {
+        super(projectLayout)
         dockerfileInstructionManager = new DockerfileInstructionManager()
     }
 

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/SystemPackagingTask.groovy
@@ -20,6 +20,7 @@ import com.netflix.gradle.plugins.utils.DeprecationLoggerUtils
 import groovy.transform.CompileDynamic
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
@@ -50,11 +51,14 @@ abstract class SystemPackagingTask extends OsPackageAbstractArchiveTask {
     @Internal
     ProjectPackagingExtension parentExten
 
+    @Internal
+    ProjectLayout projectLayout
+
     // TODO Add conventions to pull from extension
-    SystemPackagingTask() {
+    SystemPackagingTask(ProjectLayout projectLayout) {
         super()
         exten = new SystemPackagingExtension()
-
+        this.projectLayout = projectLayout
         // I have no idea where Project came from
         parentExten = project.extensions.findByType(ProjectPackagingExtension)
         if (parentExten) {

--- a/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/rpm/Rpm.groovy
@@ -19,6 +19,7 @@ package com.netflix.gradle.plugins.rpm
 import com.netflix.gradle.plugins.packaging.AbstractPackagingCopyAction
 import com.netflix.gradle.plugins.packaging.SystemPackagingTask
 import com.netflix.gradle.plugins.utils.DeprecationLoggerUtils
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
@@ -30,6 +31,8 @@ import org.redline_rpm.header.RpmType
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.internal.IConventionAware
 
+import javax.inject.Inject
+
 @DisableCachingByDefault
 class Rpm extends SystemPackagingTask {
     @InputFile
@@ -37,8 +40,9 @@ class Rpm extends SystemPackagingTask {
     @PathSensitive(PathSensitivity.NONE)
     File changeLogFile
 
-    Rpm() {
-        super()
+    @Inject
+    Rpm(ProjectLayout projectLayout) {
+        super(projectLayout)
         archiveExtension.set 'rpm'
         notCompatibleWithConfigurationCache("nebula.ospackage does not support configuration cache")
     }


### PR DESCRIPTION
While testing gradle 8.12 rc 1 & 2 we realised they introduced a few more deprecations and that broke our build.

This fixes the deprecation warnings we saw. We use jitpack to test this in our build here: https://github.com/elastic/elasticsearch/pull/118683
- We should not reference project from task execution phase