### PR TITLE
Update and fix plugin compatibility with Gradle 8.13-rc-1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f22cfbc3bd7e2e762910ed22926614b11af5af23456cec8730cde390b3e6da58
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-milestone-3-bin.zip
+distributionSha256Sum=3b3565efd2df2dd999774b6ef8ea571878c5532cbac6dbaaeb4b2731f42e6704
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-rc-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/ProjectPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/ProjectPackagingExtension.groovy
@@ -15,6 +15,7 @@ import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.internal.file.copy.DefaultCopySpec
+import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.util.PatternSet
@@ -44,7 +45,12 @@ class ProjectPackagingExtension extends SystemPackagingExtension {
     public ProjectPackagingExtension(Project project) {
         FileResolver resolver = ((ProjectInternal) project).getFileResolver();
         Instantiator instantiator = ((ProjectInternal) project).getServices().get(Instantiator.class);
-        if (GradleVersion.current().baseVersion >= GradleVersion.version("8.3") || GradleVersion.current().version.startsWith('8.3')) {
+        if (GradleVersion.current().baseVersion >= GradleVersion.version("8.13") || GradleVersion.current().version.startsWith('8.13')) {
+            FileCollectionFactory fileCollectionFactory = ((ProjectInternal) project).getServices().get(FileCollectionFactory.class);
+            PropertyFactory propertyFactory = ((ProjectInternal) project).getServices().get(PropertyFactory.class);
+            Factory<PatternSet> patternSetFactory =  new PatternSets.PatternSetFactory(PatternSpecFactory.INSTANCE)
+            delegateCopySpec = new DefaultCopySpec(fileCollectionFactory, propertyFactory, instantiator, patternSetFactory);
+        } else if (GradleVersion.current().baseVersion >= GradleVersion.version("8.3") || GradleVersion.current().version.startsWith('8.3')) {
             FileCollectionFactory fileCollectionFactory = ((ProjectInternal) project).getServices().get(FileCollectionFactory.class);
             Factory<PatternSet> patternSetFactory =  new PatternSets.PatternSetFactory(PatternSpecFactory.INSTANCE)
             delegateCopySpec = new DefaultCopySpec(fileCollectionFactory, project.objects, instantiator, patternSetFactory);


### PR DESCRIPTION
The constructur of the DefaultCopySpec has changed and requires special handling for newer Gradle versions