### PR TITLE
Fix Gradle 8.14 compatibility

### DIFF
--- a/src/main/groovy/com/netflix/gradle/plugins/packaging/ProjectPackagingExtension.groovy
+++ b/src/main/groovy/com/netflix/gradle/plugins/packaging/ProjectPackagingExtension.groovy
@@ -16,12 +16,8 @@ import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.internal.file.copy.DefaultCopySpec
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.api.specs.Spec
-import org.gradle.api.tasks.util.PatternSet
 import org.gradle.api.tasks.util.internal.PatternSets
-import org.gradle.api.tasks.util.internal.PatternSpecFactory
-import org.gradle.internal.Factory
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.util.GradleVersion
 
@@ -46,18 +42,15 @@ class ProjectPackagingExtension extends SystemPackagingExtension {
     ProjectPackagingExtension(Project project) {
         FileResolver resolver = ((ProjectInternal) project).getFileResolver();
         Instantiator instantiator = ((ProjectInternal) project).getServices().get(Instantiator.class);
-         if (GradleVersion.current().baseVersion >= GradleVersion.version("8.13") || GradleVersion.current().version.startsWith('8.13')) {
-            FileCollectionFactory fileCollectionFactory = ((ProjectInternal) project).getServices().get(FileCollectionFactory.class)
-            PropertyFactory propertyFactory = ((ProjectInternal) project).getServices().get(PropertyFactory.class)
-                def patternSetFactory =  PatternSets.getNonCachingPatternSetFactory()
-            delegateCopySpec = new DefaultCopySpec(fileCollectionFactory, propertyFactory, instantiator, patternSetFactory)
-        }  else if (GradleVersion.current().baseVersion >= GradleVersion.version("8.3") || GradleVersion.current().version.startsWith('8.3')) {
+        if (GradleVersion.current().baseVersion >= GradleVersion.version("8.13") || GradleVersion.current().version.startsWith('8.13')) {
+            delegateCopySpec = project.getObjects().newInstance(DefaultCopySpec.class);
+        } else if (GradleVersion.current().baseVersion >= GradleVersion.version("8.3") || GradleVersion.current().version.startsWith('8.3')) {
             FileCollectionFactory fileCollectionFactory = ((ProjectInternal) project).getServices().get(FileCollectionFactory.class);
-            def patternSetFactory =  PatternSets.getNonCachingPatternSetFactory()
+            def patternSetFactory = PatternSets.getNonCachingPatternSetFactory()
             delegateCopySpec = new DefaultCopySpec(fileCollectionFactory, project.objects, instantiator, patternSetFactory);
         } else if (GradleVersion.current().baseVersion >= GradleVersion.version("6.4") || GradleVersion.current().version.startsWith('6.4')) {
             FileCollectionFactory fileCollectionFactory = ((ProjectInternal) project).getServices().get(FileCollectionFactory.class);
-             def patternSetFactory =  PatternSets.getNonCachingPatternSetFactory()
+            def patternSetFactory = PatternSets.getNonCachingPatternSetFactory()
             delegateCopySpec = new DefaultCopySpec(fileCollectionFactory, instantiator, patternSetFactory);
         } else if (GradleVersion.current().baseVersion >= GradleVersion.version("6.0")) {
             FileCollectionFactory fileCollectionFactory = ((ProjectInternal) project).getServices().get(FileCollectionFactory.class);


### PR DESCRIPTION
This simplifies creating DefaultCopySpec in ProjectPackagingExtension to fix compatibility issue with Gradle 8.14-rc-1.
It also simplifies DefaultCopySpec creation for 8.13