### PR TITLE
Avoid intermediate sync task

### DIFF
--- a/src/test/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPluginLauncherSpec.groovy
+++ b/src/test/groovy/com/netflix/gradle/plugins/application/OspackageApplicationSpringBootPluginLauncherSpec.groovy
@@ -63,7 +63,7 @@ class OspackageApplicationSpringBootPluginLauncherSpec extends BaseIntegrationTe
 
             repositories {
                 mavenCentral()
-                maven { url 'https://repo.spring.io/milestone' }
+                maven { url = 'https://repo.spring.io/milestone' }
             }
 
             dependencies {


### PR DESCRIPTION
We've been unnecessarily using an intermediate `installDist` task here, when we can use the `CopySpec` directly.